### PR TITLE
Disable delete operations by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,6 @@ DATAVERSE_RESOURCE_URL=https://your-org.crm.dynamics.com
 
 # Optional: filter entities by prefix (e.g. cr123_)
 # DATAVERSE_ENTITY_PREFIX=
+
+# Optional: enable delete operations (disabled by default for safety)
+# DATAVERSE_ALLOW_DELETE=true

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ MCP (Model Context Protocol) server for Microsoft Dataverse API. Works with any 
 | `get_record` | Get a single record by ID |
 | `create_record` | Create a record |
 | `update_record` | Update a record |
-| `delete_record` | Delete a record |
+| `delete_record` | Delete a record (disabled by default, see [Safety](#safety)) |
 
 ### Schema operations
 | Tool | Description |
@@ -32,6 +32,7 @@ DATAVERSE_CLIENT_ID=your-app-registration-client-id
 DATAVERSE_CLIENT_SECRET=your-client-secret
 DATAVERSE_RESOURCE_URL=https://your-org.crm.dynamics.com
 DATAVERSE_ENTITY_PREFIX=contoso_          # optional, default prefix filter for list_entities
+DATAVERSE_ALLOW_DELETE=true               # optional, enable delete operations (disabled by default)
 ```
 
 ### Azure App Registration
@@ -64,6 +65,12 @@ Add `.mcp.json` to your project root:
 ```
 
 Create a `.env` file with your credentials (see `.env.example`).
+
+## Safety
+
+Delete operations are **disabled by default** to prevent accidental data loss. The `delete_record` tool is registered but returns an error message explaining how to enable it.
+
+To enable, add `DATAVERSE_ALLOW_DELETE=true` to your `.env` file and restart the MCP server.
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,11 +71,12 @@ if (missing.length > 0) {
   const clientSecret = process.env.DATAVERSE_CLIENT_SECRET as string;
   const resourceUrl = process.env.DATAVERSE_RESOURCE_URL as string;
   const entityPrefix = process.env.DATAVERSE_ENTITY_PREFIX || undefined;
+  const allowDelete = process.env.DATAVERSE_ALLOW_DELETE === "true";
 
   const auth = new DataverseAuth(tenantId, clientId, clientSecret, resourceUrl);
   const client = new DataverseClient(auth, resourceUrl);
 
-  registerDataTools(server, client, entityPrefix);
+  registerDataTools(server, client, entityPrefix, allowDelete);
   registerSchemaTools(server, client);
 }
 

--- a/src/tools/data-tools.ts
+++ b/src/tools/data-tools.ts
@@ -21,6 +21,7 @@ export function registerDataTools(
   server: McpServer,
   client: DataverseClient,
   defaultPrefix?: string,
+  allowDelete = false,
 ): void {
   server.tool(
     "list_entities",
@@ -205,22 +206,51 @@ export function registerDataTools(
     },
   );
 
-  server.tool(
-    "delete_record",
-    "Delete a record from a Dataverse table",
-    {
-      entity_set: z
-        .string()
-        .describe("Entity set name (plural, e.g. 'accounts', 'contacts')"),
-      id: z.string().describe("Record GUID"),
-    },
-    async ({ entity_set, id }) => {
-      await client.delete(`/${entity_set}(${id})`);
-      return {
+  if (allowDelete) {
+    server.tool(
+      "delete_record",
+      "Delete a record from a Dataverse table",
+      {
+        entity_set: z
+          .string()
+          .describe("Entity set name (plural, e.g. 'accounts', 'contacts')"),
+        id: z.string().describe("Record GUID"),
+      },
+      async ({ entity_set, id }) => {
+        await client.delete(`/${entity_set}(${id})`);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Record ${id} deleted successfully.`,
+            },
+          ],
+        };
+      },
+    );
+  } else {
+    server.tool(
+      "delete_record",
+      "Delete a record from a Dataverse table (currently disabled)",
+      {
+        entity_set: z.string().describe("Entity set name"),
+        id: z.string().describe("Record GUID"),
+      },
+      async () => ({
         content: [
-          { type: "text" as const, text: `Record ${id} deleted successfully.` },
+          {
+            type: "text" as const,
+            text: [
+              "[IMPORTANT: Display this entire message to the user exactly as-is.]",
+              "",
+              "⚠️ Delete operations are disabled by default for safety.",
+              "",
+              "To enable, add DATAVERSE_ALLOW_DELETE=true to your .env file and restart the MCP server.",
+            ].join("\n"),
+          },
         ],
-      };
-    },
-  );
+        isError: true,
+      }),
+    );
+  }
 }

--- a/tests/data-tools.test.ts
+++ b/tests/data-tools.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { registerDataTools } from "../src/tools/data-tools.js";
+
+function createMockServer() {
+  const tools = new Map<string, { description: string; handler: Function }>();
+  return {
+    tool: vi.fn(
+      (name: string, description: string, _schema: unknown, handler: Function) => {
+        tools.set(name, { description, handler });
+      },
+    ),
+    tools,
+  };
+}
+
+const mockClient = {} as Parameters<typeof registerDataTools>[1];
+
+describe("registerDataTools allowDelete", () => {
+  it("delete_record returns error when allowDelete is false", async () => {
+    const server = createMockServer();
+    registerDataTools(server as any, mockClient, undefined, false);
+
+    const deleteTool = server.tools.get("delete_record");
+    expect(deleteTool).toBeDefined();
+    expect(deleteTool!.description).toContain("disabled");
+
+    const result = await deleteTool!.handler({ entity_set: "leads", id: "123" });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("DATAVERSE_ALLOW_DELETE");
+  });
+
+  it("delete_record calls client.delete when allowDelete is true", async () => {
+    const server = createMockServer();
+    const client = { delete: vi.fn() } as any;
+    registerDataTools(server as any, client, undefined, true);
+
+    const deleteTool = server.tools.get("delete_record");
+    expect(deleteTool).toBeDefined();
+    expect(deleteTool!.description).not.toContain("disabled");
+
+    await deleteTool!.handler({ entity_set: "leads", id: "123" });
+    expect(client.delete).toHaveBeenCalledWith("/leads(123)");
+  });
+});


### PR DESCRIPTION
## Summary
- `delete_record` tool is now blocked unless `DATAVERSE_ALLOW_DELETE=true` is set in `.env`
- When disabled, the tool returns an error message with instructions how to enable
- Updated README with Safety section and `.env.example`

## Test plan
- [x] Verified locally: without env var — tool returns error message
- [x] Verified locally: with `DATAVERSE_ALLOW_DELETE=true` — tool works normally
- [x] Any typo (e.g. `fulse`) defaults to disabled (strict `=== "true"` check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)