### PR TITLE
Add solution filter for list_entities and list_solutions tool

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,8 @@ DATAVERSE_RESOURCE_URL=https://your-org.crm.dynamics.com
 # Optional: filter entities by prefix (e.g. cr123_)
 # DATAVERSE_ENTITY_PREFIX=
 
+# Optional: default solution unique name to filter list_entities (e.g. MySolution)
+# DATAVERSE_SOLUTION_NAME=
+
 # Optional: enable delete operations (disabled by default for safety)
 # DATAVERSE_ALLOW_DELETE=true

--- a/README.md
+++ b/README.md
@@ -7,13 +7,16 @@ MCP (Model Context Protocol) server for Microsoft Dataverse API with [safe-by-de
 ### Data operations
 | Tool | Description |
 |------|-------------|
-| `list_entities` | List Dataverse tables with optional prefix filter |
+| `list_entities` | List Dataverse tables with optional prefix and solution filters |
+| `list_solutions` | List Dataverse solutions (use `uniquename` to filter `list_entities`) |
 | `get_entity_schema` | Get attributes of a specific table |
 | `query_records` | Query records with OData $filter, $select, $top, $orderby, $expand |
 | `get_record` | Get a single record by ID |
 | `create_record` | Create a record |
 | `update_record` | Update a record |
 | `delete_record` | Delete a record (disabled by default, see [Safety](#safety)) |
+
+> Note: `solution` / `DATAVERSE_SOLUTION_NAME` only scopes `list_entities` (schema browsing). Data tools (`query_records`, `get_record`, `create_record`, …) keep full access to any table regardless of solution membership — shared tables like `account` or `contact` remain reachable.
 
 ### Schema operations
 | Tool | Description |
@@ -32,6 +35,7 @@ DATAVERSE_CLIENT_ID=your-app-registration-client-id
 DATAVERSE_CLIENT_SECRET=your-client-secret
 DATAVERSE_RESOURCE_URL=https://your-org.crm.dynamics.com
 DATAVERSE_ENTITY_PREFIX=contoso_          # optional, default prefix filter for list_entities
+DATAVERSE_SOLUTION_NAME=MySolution        # optional, default solution unique name for list_entities
 DATAVERSE_ALLOW_DELETE=true               # optional, enable delete operations (disabled by default)
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,12 +71,13 @@ if (missing.length > 0) {
   const clientSecret = process.env.DATAVERSE_CLIENT_SECRET as string;
   const resourceUrl = process.env.DATAVERSE_RESOURCE_URL as string;
   const entityPrefix = process.env.DATAVERSE_ENTITY_PREFIX || undefined;
+  const solutionName = process.env.DATAVERSE_SOLUTION_NAME || undefined;
   const allowDelete = process.env.DATAVERSE_ALLOW_DELETE === "true";
 
   const auth = new DataverseAuth(tenantId, clientId, clientSecret, resourceUrl);
   const client = new DataverseClient(auth, resourceUrl);
 
-  registerDataTools(server, client, entityPrefix, allowDelete);
+  registerDataTools(server, client, entityPrefix, allowDelete, solutionName);
   registerSchemaTools(server, client);
 }
 

--- a/src/tools/data-tools.ts
+++ b/src/tools/data-tools.ts
@@ -17,15 +17,47 @@ export function buildODataQuery(
   return str ? `?${str}` : "";
 }
 
+const SOLUTION_ID_CHUNK_SIZE = 50;
+
+async function getEntityIdsInSolution(
+  client: DataverseClient,
+  solutionUniqueName: string,
+): Promise<string[]> {
+  const solutionsQuery = buildODataQuery({
+    $select: "solutionid",
+    $filter: `uniquename eq '${escapeODataString(solutionUniqueName)}'`,
+  });
+  const solutionsResult = (await client.get(`/solutions${solutionsQuery}`)) as {
+    value: Array<{ solutionid: string }>;
+  };
+  if (solutionsResult.value.length === 0) {
+    throw new Error(
+      `Solution not found: '${solutionUniqueName}'. Use list_solutions to see available solutions.`,
+    );
+  }
+  const solutionId = solutionsResult.value[0].solutionid;
+
+  // componenttype = 1 is Entity (table)
+  const componentsQuery = buildODataQuery({
+    $select: "objectid",
+    $filter: `_solutionid_value eq ${solutionId} and componenttype eq 1`,
+  });
+  const componentsResult = (await client.get(
+    `/solutioncomponents${componentsQuery}`,
+  )) as { value: Array<{ objectid: string }> };
+  return componentsResult.value.map((c) => c.objectid);
+}
+
 export function registerDataTools(
   server: McpServer,
   client: DataverseClient,
   defaultPrefix?: string,
   allowDelete = false,
+  defaultSolution?: string,
 ): void {
   server.tool(
     "list_entities",
-    "List Dataverse tables (entities) with optional prefix filter",
+    "List Dataverse tables (entities) with optional prefix and solution filters",
     {
       prefix: z
         .string()
@@ -33,18 +65,102 @@ export function registerDataTools(
         .describe(
           "Filter entities by logical name prefix (e.g. 'contoso_'). Uses DATAVERSE_ENTITY_PREFIX env if not specified.",
         ),
+      solution: z
+        .string()
+        .optional()
+        .describe(
+          "Filter entities by solution unique name (e.g. 'MySolution'). Uses DATAVERSE_SOLUTION_NAME env if not specified. Pass an empty string to disable the default filter.",
+        ),
     },
-    async ({ prefix }) => {
+    async ({ prefix, solution }) => {
       const effectivePrefix = prefix ?? defaultPrefix;
+      const effectiveSolution =
+        solution === undefined ? defaultSolution : solution || undefined;
+
+      const filterParts: string[] = [];
+
+      if (effectiveSolution) {
+        const entityIds = await getEntityIdsInSolution(
+          client,
+          effectiveSolution,
+        );
+        if (entityIds.length === 0) {
+          return {
+            content: [{ type: "text" as const, text: "[]" }],
+          };
+        }
+        // Dataverse Metadata entities reject `startswith` combined with `or`,
+        // so prefix is applied client-side when a solution filter is active.
+        const entities: Array<{ LogicalName?: string }> = [];
+        for (let i = 0; i < entityIds.length; i += SOLUTION_ID_CHUNK_SIZE) {
+          const chunk = entityIds.slice(i, i + SOLUTION_ID_CHUNK_SIZE);
+          const query = buildODataQuery({
+            $select:
+              "LogicalName,DisplayName,EntitySetName,Description,IsCustomEntity",
+            $filter: `(${chunk.map((id) => `MetadataId eq ${id}`).join(" or ")})`,
+          });
+          const result = (await client.get(`/EntityDefinitions${query}`)) as {
+            value: Array<{ LogicalName?: string }>;
+          };
+          entities.push(...result.value);
+        }
+        const filtered = effectivePrefix
+          ? entities.filter((e) => e.LogicalName?.startsWith(effectivePrefix))
+          : entities;
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(filtered, null, 2) },
+          ],
+        };
+      }
+
+      if (effectivePrefix) {
+        filterParts.push(
+          `startswith(LogicalName,'${escapeODataString(effectivePrefix)}')`,
+        );
+      }
       const params: Record<string, string | undefined> = {
         $select:
           "LogicalName,DisplayName,EntitySetName,Description,IsCustomEntity",
       };
-      if (effectivePrefix) {
-        params.$filter = `startswith(LogicalName,'${escapeODataString(effectivePrefix)}')`;
+      if (filterParts.length > 0) {
+        params.$filter = filterParts.join(" and ");
       }
       const query = buildODataQuery(params);
       const result = (await client.get(`/EntityDefinitions${query}`)) as {
+        value: unknown[];
+      };
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(result.value, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    "list_solutions",
+    "List Dataverse solutions (uniquename is used to filter list_entities)",
+    {
+      include_managed: z
+        .boolean()
+        .optional()
+        .describe(
+          "Include managed solutions (default: false — only unmanaged are returned)",
+        ),
+    },
+    async ({ include_managed }) => {
+      const filters = ["isvisible eq true"];
+      if (!include_managed) filters.push("ismanaged eq false");
+      const query = buildODataQuery({
+        $select: "solutionid,uniquename,friendlyname,version,ismanaged",
+        $filter: filters.join(" and "),
+        $orderby: "friendlyname",
+      });
+      const result = (await client.get(`/solutions${query}`)) as {
         value: unknown[];
       };
       return {

--- a/src/tools/data-tools.ts
+++ b/src/tools/data-tools.ts
@@ -17,7 +17,24 @@ export function buildODataQuery(
   return str ? `?${str}` : "";
 }
 
-const SOLUTION_ID_CHUNK_SIZE = 50;
+const METADATA_ID_CHUNK_SIZE = 50;
+
+async function fetchAllPages<T>(
+  client: DataverseClient,
+  path: string,
+): Promise<T[]> {
+  const results: T[] = [];
+  let next: string | undefined = path;
+  while (next) {
+    const page = (await client.get(next)) as {
+      value: T[];
+      "@odata.nextLink"?: string;
+    };
+    results.push(...page.value);
+    next = page["@odata.nextLink"];
+  }
+  return results;
+}
 
 async function getEntityIdsInSolution(
   client: DataverseClient,
@@ -42,10 +59,11 @@ async function getEntityIdsInSolution(
     $select: "objectid",
     $filter: `_solutionid_value eq ${solutionId} and componenttype eq 1`,
   });
-  const componentsResult = (await client.get(
+  const components = await fetchAllPages<{ objectid: string }>(
+    client,
     `/solutioncomponents${componentsQuery}`,
-  )) as { value: Array<{ objectid: string }> };
-  return componentsResult.value.map((c) => c.objectid);
+  );
+  return components.map((c) => c.objectid);
 }
 
 export function registerDataTools(
@@ -92,8 +110,8 @@ export function registerDataTools(
         // Dataverse Metadata entities reject `startswith` combined with `or`,
         // so prefix is applied client-side when a solution filter is active.
         const entities: Array<{ LogicalName?: string }> = [];
-        for (let i = 0; i < entityIds.length; i += SOLUTION_ID_CHUNK_SIZE) {
-          const chunk = entityIds.slice(i, i + SOLUTION_ID_CHUNK_SIZE);
+        for (let i = 0; i < entityIds.length; i += METADATA_ID_CHUNK_SIZE) {
+          const chunk = entityIds.slice(i, i + METADATA_ID_CHUNK_SIZE);
           const query = buildODataQuery({
             $select:
               "LogicalName,DisplayName,EntitySetName,Description,IsCustomEntity",
@@ -160,14 +178,15 @@ export function registerDataTools(
         $filter: filters.join(" and "),
         $orderby: "friendlyname",
       });
-      const result = (await client.get(`/solutions${query}`)) as {
-        value: unknown[];
-      };
+      const solutions = await fetchAllPages<unknown>(
+        client,
+        `/solutions${query}`,
+      );
       return {
         content: [
           {
             type: "text" as const,
-            text: JSON.stringify(result.value, null, 2),
+            text: JSON.stringify(solutions, null, 2),
           },
         ],
       };

--- a/tests/data-tools.test.ts
+++ b/tests/data-tools.test.ts
@@ -15,6 +15,232 @@ function createMockServer() {
 
 const mockClient = {} as Parameters<typeof registerDataTools>[1];
 
+describe("list_solutions", () => {
+  it("queries /solutions excluding managed by default", async () => {
+    const server = createMockServer();
+    const client = {
+      get: vi.fn().mockResolvedValue({ value: [{ uniquename: "Default" }] }),
+    } as any;
+    registerDataTools(server as any, client);
+
+    const tool = server.tools.get("list_solutions");
+    expect(tool).toBeDefined();
+
+    const result = await tool!.handler({});
+    expect(client.get).toHaveBeenCalledTimes(1);
+    const url = client.get.mock.calls[0][0] as string;
+    expect(url).toMatch(/^\/solutions\?/);
+    const qs = new URLSearchParams(url.slice(url.indexOf("?") + 1));
+    expect(qs.get("$filter")).toBe("isvisible eq true and ismanaged eq false");
+    expect(qs.get("$select")).toContain("uniquename");
+    expect(result.content[0].text).toContain("Default");
+  });
+
+  it("includes managed solutions when include_managed=true", async () => {
+    const server = createMockServer();
+    const client = { get: vi.fn().mockResolvedValue({ value: [] }) } as any;
+    registerDataTools(server as any, client);
+
+    await server.tools.get("list_solutions")!.handler({ include_managed: true });
+    const url = client.get.mock.calls[0][0] as string;
+    const qs = new URLSearchParams(url.slice(url.indexOf("?") + 1));
+    expect(qs.get("$filter")).toBe("isvisible eq true");
+  });
+});
+
+describe("list_entities solution filter", () => {
+  it("uses prefix only when no solution is set", async () => {
+    const server = createMockServer();
+    const client = {
+      get: vi.fn().mockResolvedValue({ value: [{ LogicalName: "contoso_x" }] }),
+    } as any;
+    registerDataTools(server as any, client, "contoso_");
+
+    await server.tools.get("list_entities")!.handler({});
+    expect(client.get).toHaveBeenCalledTimes(1);
+    const url = client.get.mock.calls[0][0] as string;
+    const qs = new URLSearchParams(url.slice(url.indexOf("?") + 1));
+    expect(qs.get("$filter")).toBe("startswith(LogicalName,'contoso_')");
+  });
+
+  it("resolves solution to entity MetadataIds and filters", async () => {
+    const server = createMockServer();
+    const solutionId = "11111111-1111-1111-1111-111111111111";
+    const entityA = "22222222-2222-2222-2222-222222222222";
+    const entityB = "33333333-3333-3333-3333-333333333333";
+    const client = {
+      get: vi
+        .fn()
+        .mockResolvedValueOnce({ value: [{ solutionid: solutionId }] })
+        .mockResolvedValueOnce({
+          value: [{ objectid: entityA }, { objectid: entityB }],
+        })
+        .mockResolvedValueOnce({
+          value: [{ LogicalName: "contoso_a" }, { LogicalName: "contoso_b" }],
+        }),
+    } as any;
+    registerDataTools(server as any, client);
+
+    const result = await server.tools
+      .get("list_entities")!
+      .handler({ solution: "MySolution" });
+
+    expect(client.get).toHaveBeenCalledTimes(3);
+    const solutionsUrl = client.get.mock.calls[0][0] as string;
+    expect(solutionsUrl).toMatch(/^\/solutions\?/);
+    expect(
+      new URLSearchParams(solutionsUrl.slice(solutionsUrl.indexOf("?") + 1)).get(
+        "$filter",
+      ),
+    ).toBe("uniquename eq 'MySolution'");
+
+    const componentsUrl = client.get.mock.calls[1][0] as string;
+    expect(componentsUrl).toMatch(/^\/solutioncomponents\?/);
+    const componentsQs = new URLSearchParams(
+      componentsUrl.slice(componentsUrl.indexOf("?") + 1),
+    );
+    expect(componentsQs.get("$filter")).toBe(
+      `_solutionid_value eq ${solutionId} and componenttype eq 1`,
+    );
+
+    const entitiesUrl = client.get.mock.calls[2][0] as string;
+    expect(entitiesUrl).toMatch(/^\/EntityDefinitions\?/);
+    const entitiesQs = new URLSearchParams(
+      entitiesUrl.slice(entitiesUrl.indexOf("?") + 1),
+    );
+    expect(entitiesQs.get("$filter")).toBe(
+      `(MetadataId eq ${entityA} or MetadataId eq ${entityB})`,
+    );
+    expect(result.content[0].text).toContain("contoso_a");
+    expect(result.content[0].text).toContain("contoso_b");
+  });
+
+  it("applies prefix client-side when combined with solution (Dataverse rejects startswith+or on metadata)", async () => {
+    const server = createMockServer();
+    const solutionId = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    const entityA = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    const entityB = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+    const client = {
+      get: vi
+        .fn()
+        .mockResolvedValueOnce({ value: [{ solutionid: solutionId }] })
+        .mockResolvedValueOnce({
+          value: [{ objectid: entityA }, { objectid: entityB }],
+        })
+        .mockResolvedValueOnce({
+          value: [
+            { LogicalName: "contoso_a" },
+            { LogicalName: "account" },
+          ],
+        }),
+    } as any;
+    registerDataTools(server as any, client, "contoso_");
+
+    const result = await server.tools
+      .get("list_entities")!
+      .handler({ solution: "MySolution" });
+
+    const entitiesUrl = client.get.mock.calls[2][0] as string;
+    const entitiesQs = new URLSearchParams(
+      entitiesUrl.slice(entitiesUrl.indexOf("?") + 1),
+    );
+    // prefix MUST NOT be in the OData filter — it is applied client-side
+    expect(entitiesQs.get("$filter")).toBe(
+      `(MetadataId eq ${entityA} or MetadataId eq ${entityB})`,
+    );
+    expect(result.content[0].text).toContain("contoso_a");
+    expect(result.content[0].text).not.toContain("account");
+  });
+
+  it("uses default solution when parameter omitted", async () => {
+    const server = createMockServer();
+    const solutionId = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+    const client = {
+      get: vi
+        .fn()
+        .mockResolvedValueOnce({ value: [{ solutionid: solutionId }] })
+        .mockResolvedValueOnce({ value: [] }),
+    } as any;
+    registerDataTools(server as any, client, undefined, false, "DefaultSol");
+
+    const result = await server.tools.get("list_entities")!.handler({});
+    expect(client.get).toHaveBeenCalledTimes(2);
+    const solutionsUrl = client.get.mock.calls[0][0] as string;
+    const solutionsQs = new URLSearchParams(
+      solutionsUrl.slice(solutionsUrl.indexOf("?") + 1),
+    );
+    expect(solutionsQs.get("$filter")).toBe("uniquename eq 'DefaultSol'");
+    expect(result.content[0].text).toBe("[]");
+  });
+
+  it("empty-string solution parameter disables default solution filter", async () => {
+    const server = createMockServer();
+    const client = { get: vi.fn().mockResolvedValue({ value: [] }) } as any;
+    registerDataTools(server as any, client, undefined, false, "DefaultSol");
+
+    await server.tools.get("list_entities")!.handler({ solution: "" });
+    expect(client.get).toHaveBeenCalledTimes(1);
+    const url = client.get.mock.calls[0][0] as string;
+    expect(url).toMatch(/^\/EntityDefinitions/);
+    expect(url).not.toContain("%24filter");
+  });
+
+  it("throws a helpful error when solution is not found", async () => {
+    const server = createMockServer();
+    const client = {
+      get: vi.fn().mockResolvedValueOnce({ value: [] }),
+    } as any;
+    registerDataTools(server as any, client);
+
+    await expect(
+      server.tools.get("list_entities")!.handler({ solution: "Missing" }),
+    ).rejects.toThrow(/Solution not found: 'Missing'/);
+  });
+
+  it("returns empty array when solution has no entity components", async () => {
+    const server = createMockServer();
+    const solutionId = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+    const client = {
+      get: vi
+        .fn()
+        .mockResolvedValueOnce({ value: [{ solutionid: solutionId }] })
+        .mockResolvedValueOnce({ value: [] }),
+    } as any;
+    registerDataTools(server as any, client);
+
+    const result = await server.tools
+      .get("list_entities")!
+      .handler({ solution: "Empty" });
+    expect(client.get).toHaveBeenCalledTimes(2);
+    expect(result.content[0].text).toBe("[]");
+  });
+
+  it("chunks large MetadataId lists into multiple EntityDefinitions calls", async () => {
+    const server = createMockServer();
+    const solutionId = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+    const ids = Array.from({ length: 120 }, (_, i) =>
+      `00000000-0000-0000-0000-${String(i).padStart(12, "0")}`,
+    );
+    const client = {
+      get: vi
+        .fn()
+        .mockResolvedValueOnce({ value: [{ solutionid: solutionId }] })
+        .mockResolvedValueOnce({
+          value: ids.map((objectid) => ({ objectid })),
+        })
+        .mockResolvedValue({ value: [] }),
+    } as any;
+    registerDataTools(server as any, client);
+
+    await server.tools
+      .get("list_entities")!
+      .handler({ solution: "Huge" });
+
+    // 1 solutions + 1 components + ceil(120 / 50) = 3 entity chunks = 5 total
+    expect(client.get).toHaveBeenCalledTimes(5);
+  });
+});
+
 describe("registerDataTools allowDelete", () => {
   it("delete_record returns error when allowDelete is false", async () => {
     const server = createMockServer();

--- a/tests/data-tools.test.ts
+++ b/tests/data-tools.test.ts
@@ -46,6 +46,28 @@ describe("list_solutions", () => {
     const qs = new URLSearchParams(url.slice(url.indexOf("?") + 1));
     expect(qs.get("$filter")).toBe("isvisible eq true");
   });
+
+  it("follows @odata.nextLink when solutions response is paginated", async () => {
+    const server = createMockServer();
+    const nextLink =
+      "https://org.crm.dynamics.com/api/data/v9.2/solutions?$skiptoken=page2";
+    const client = {
+      get: vi
+        .fn()
+        .mockResolvedValueOnce({
+          value: [{ uniquename: "A" }],
+          "@odata.nextLink": nextLink,
+        })
+        .mockResolvedValueOnce({ value: [{ uniquename: "B" }] }),
+    } as any;
+    registerDataTools(server as any, client);
+
+    const result = await server.tools.get("list_solutions")!.handler({});
+    expect(client.get).toHaveBeenCalledTimes(2);
+    expect(client.get.mock.calls[1][0]).toBe(nextLink);
+    expect(result.content[0].text).toContain('"A"');
+    expect(result.content[0].text).toContain('"B"');
+  });
 });
 
 describe("list_entities solution filter", () => {
@@ -213,6 +235,43 @@ describe("list_entities solution filter", () => {
       .handler({ solution: "Empty" });
     expect(client.get).toHaveBeenCalledTimes(2);
     expect(result.content[0].text).toBe("[]");
+  });
+
+  it("follows @odata.nextLink when solutioncomponents is paginated", async () => {
+    const server = createMockServer();
+    const solutionId = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+    const entityA = "11111111-2222-3333-4444-555555555555";
+    const entityB = "22222222-3333-4444-5555-666666666666";
+    const nextLink =
+      "https://org.crm.dynamics.com/api/data/v9.2/solutioncomponents?$skiptoken=page2";
+    const client = {
+      get: vi
+        .fn()
+        .mockResolvedValueOnce({ value: [{ solutionid: solutionId }] })
+        .mockResolvedValueOnce({
+          value: [{ objectid: entityA }],
+          "@odata.nextLink": nextLink,
+        })
+        .mockResolvedValueOnce({ value: [{ objectid: entityB }] })
+        .mockResolvedValueOnce({ value: [] }),
+    } as any;
+    registerDataTools(server as any, client);
+
+    await server.tools
+      .get("list_entities")!
+      .handler({ solution: "Paged" });
+
+    // solutions + components page1 + components page2 + entities chunk
+    expect(client.get).toHaveBeenCalledTimes(4);
+    expect(client.get.mock.calls[2][0]).toBe(nextLink);
+
+    const entitiesUrl = client.get.mock.calls[3][0] as string;
+    const entitiesQs = new URLSearchParams(
+      entitiesUrl.slice(entitiesUrl.indexOf("?") + 1),
+    );
+    expect(entitiesQs.get("$filter")).toBe(
+      `(MetadataId eq ${entityA} or MetadataId eq ${entityB})`,
+    );
   });
 
   it("chunks large MetadataId lists into multiple EntityDefinitions calls", async () => {


### PR DESCRIPTION
Closes #13.

## Summary
- Add `DATAVERSE_SOLUTION_NAME` env var — default solution filter for `list_entities`
- Add `list_solutions` tool — returns unmanaged solutions (pass `include_managed: true` to see all)
- Add optional `solution` parameter on `list_entities` — per-call override of the env default; empty string disables the default

Only `list_entities` (schema browsing) is scoped by solution. Data tools (`query_records`, `get_record`, `create_record`, …) keep full access to any table regardless of solution membership.

## Implementation notes
Resolution is a 3-step flow: `uniquename` → `solutionid` → `solutioncomponents` (filtered to `componenttype eq 1`) → `EntityDefinitions` with `MetadataId eq … or …`. Large solutions are chunked at 50 MetadataIds per request to avoid URL length limits.

Prefix filter is applied **client-side** when combined with a solution filter — Dataverse rejects `startswith(...)` combined with `or` on Metadata entities (`501 0x8006088a`). Hit this one end-to-end against a live org, hence the workaround.

## Test plan
- [x] `npm run lint` / `npm run build` clean
- [x] 41 unit tests pass (9 new ones cover list_solutions, solution resolution, prefix+solution client-side, default env, empty-string override, not-found error, empty-components path, chunking for 120+ entities)
- [x] End-to-end against live Dataverse (`FundaiCleanSolution`, 32 entities): both `DATAVERSE_SOLUTION_NAME` + `DATAVERSE_ENTITY_PREFIX` set, vanilla `list_entities()` returns 20 `fundai_*` tables (12 non-prefix ones correctly filtered out client-side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)