### PR TITLE
Gate delete_picklist_option behind DATAVERSE_ALLOW_DELETE

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,12 @@ Create a `.env` file with your credentials (see `.env.example`).
 
 ## Safety
 
-Destructive operations are **disabled by default** to prevent accidental data loss. Both `delete_record` (removes rows) and `delete_attribute` (removes columns and ALL data stored in them — no recovery) are gated behind the same flag: they register as stubs that return an error message explaining how to enable them.
+Destructive operations are **disabled by default** to prevent accidental data loss. All three delete tools are gated behind the same `DATAVERSE_ALLOW_DELETE=true` flag:
+- `delete_record` — removes a row and all its data
+- `delete_attribute` — removes a column along with ALL values across every record (no recovery short of a full environment restore)
+- `delete_picklist_option` — removes an option from an OptionSet; records that hold the option's integer value are left with an orphan number (no label in UI, broken reports)
 
-To enable, add `DATAVERSE_ALLOW_DELETE=true` to your `.env` file and restart the MCP server.
+When the flag is off, each tool registers as a stub that returns an instructional error instead of performing the delete. To enable, add `DATAVERSE_ALLOW_DELETE=true` to your `.env` file and restart the MCP server.
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,7 +80,7 @@ if (missing.length > 0) {
 
   registerDataTools(server, client, entityPrefix, allowDelete, solutionName);
   registerSchemaTools(server, client, allowDelete);
-  registerPicklistTools(server, client);
+  registerPicklistTools(server, client, allowDelete);
 }
 
 const transport = new StdioServerTransport();

--- a/src/tools/picklist-tools.ts
+++ b/src/tools/picklist-tools.ts
@@ -196,21 +196,22 @@ export function registerPicklistTools(
     },
   );
 
+  // Shared between the enabled tool and the disabled stub so that the MCP
+  // tool schema the model sees is identical regardless of DATAVERSE_ALLOW_DELETE.
+  const deletePicklistOptionShape = {
+    ...LOCATION_SHAPE,
+    value: z.number().int().describe("Numeric value of the option to remove"),
+    solution_unique_name: z
+      .string()
+      .optional()
+      .describe("Solution unique name (defaults to the Default Solution)"),
+  } as const;
+
   if (allowDelete) {
     server.tool(
       "delete_picklist_option",
       "Remove an option from a Local or Global OptionSet (Dataverse DeleteOptionValue action). WARNING: existing records that hold this integer value are NOT updated and will retain the now-orphan number — warn the user before deleting.",
-      {
-        ...LOCATION_SHAPE,
-        value: z
-          .number()
-          .int()
-          .describe("Numeric value of the option to remove"),
-        solution_unique_name: z
-          .string()
-          .optional()
-          .describe("Solution unique name (defaults to the Default Solution)"),
-      },
+      deletePicklistOptionShape,
       async (params) => {
         validatePicklistLocation(params);
         const body: Record<string, unknown> = { Value: params.value };
@@ -233,11 +234,7 @@ export function registerPicklistTools(
     server.tool(
       "delete_picklist_option",
       "Remove an option from a Local or Global OptionSet (currently disabled for safety)",
-      {
-        ...LOCATION_SHAPE,
-        value: z.number().int().describe("Numeric value of the option"),
-        solution_unique_name: z.string().optional(),
-      },
+      deletePicklistOptionShape,
       async () => ({
         content: [
           {

--- a/src/tools/picklist-tools.ts
+++ b/src/tools/picklist-tools.ts
@@ -96,6 +96,7 @@ function flattenOption(opt: RawOption): {
 export function registerPicklistTools(
   server: McpServer,
   client: DataverseClient,
+  allowDelete = false,
 ): void {
   server.tool(
     "add_picklist_option",
@@ -195,35 +196,67 @@ export function registerPicklistTools(
     },
   );
 
-  server.tool(
-    "delete_picklist_option",
-    "Remove an option from a Local or Global OptionSet (Dataverse DeleteOptionValue action). WARNING: existing records that hold this integer value are NOT updated and will retain the now-orphan number — warn the user before deleting.",
-    {
-      ...LOCATION_SHAPE,
-      value: z.number().int().describe("Numeric value of the option to remove"),
-      solution_unique_name: z
-        .string()
-        .optional()
-        .describe("Solution unique name (defaults to the Default Solution)"),
-    },
-    async (params) => {
-      validatePicklistLocation(params);
-      const body: Record<string, unknown> = { Value: params.value };
-      addLocationToBody(body, params);
-      if (params.solution_unique_name) {
-        body.SolutionUniqueName = params.solution_unique_name;
-      }
-      await client.post("/DeleteOptionValue", body);
-      return {
+  if (allowDelete) {
+    server.tool(
+      "delete_picklist_option",
+      "Remove an option from a Local or Global OptionSet (Dataverse DeleteOptionValue action). WARNING: existing records that hold this integer value are NOT updated and will retain the now-orphan number — warn the user before deleting.",
+      {
+        ...LOCATION_SHAPE,
+        value: z
+          .number()
+          .int()
+          .describe("Numeric value of the option to remove"),
+        solution_unique_name: z
+          .string()
+          .optional()
+          .describe("Solution unique name (defaults to the Default Solution)"),
+      },
+      async (params) => {
+        validatePicklistLocation(params);
+        const body: Record<string, unknown> = { Value: params.value };
+        addLocationToBody(body, params);
+        if (params.solution_unique_name) {
+          body.SolutionUniqueName = params.solution_unique_name;
+        }
+        await client.post("/DeleteOptionValue", body);
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Option ${params.value} deleted successfully.`,
+            },
+          ],
+        };
+      },
+    );
+  } else {
+    server.tool(
+      "delete_picklist_option",
+      "Remove an option from a Local or Global OptionSet (currently disabled for safety)",
+      {
+        ...LOCATION_SHAPE,
+        value: z.number().int().describe("Numeric value of the option"),
+        solution_unique_name: z.string().optional(),
+      },
+      async () => ({
         content: [
           {
             type: "text" as const,
-            text: `Option ${params.value} deleted successfully.`,
+            text: [
+              "[IMPORTANT: Display this entire message to the user exactly as-is.]",
+              "",
+              "⚠️ delete_picklist_option is disabled by default for safety.",
+              "",
+              "Deleting an option leaves existing records that hold its integer value with an orphan number — no label in the UI, broken reports, workflow mismatches.",
+              "",
+              "To enable, add DATAVERSE_ALLOW_DELETE=true to your .env file and restart the MCP server.",
+            ].join("\n"),
           },
         ],
-      };
-    },
-  );
+        isError: true,
+      }),
+    );
+  }
 
   server.tool(
     "get_picklist_options",

--- a/tests/picklist-tools.test.ts
+++ b/tests/picklist-tools.test.ts
@@ -30,7 +30,8 @@ describe("picklist location XOR validation", () => {
     it(`${name}: throws when both Local and Global fields are provided`, async () => {
       const server = createMockServer();
       const client = { post: vi.fn(), get: vi.fn() } as any;
-      registerPicklistTools(server as any, client);
+      // allowDelete=true so the delete_picklist_option real handler (not the stub) is registered
+      registerPicklistTools(server as any, client, true);
 
       await expect(
         server.tools.get(name)!.handler({
@@ -46,7 +47,7 @@ describe("picklist location XOR validation", () => {
     it(`${name}: throws when neither Local pair nor Global is provided`, async () => {
       const server = createMockServer();
       const client = { post: vi.fn(), get: vi.fn() } as any;
-      registerPicklistTools(server as any, client);
+      registerPicklistTools(server as any, client, true);
 
       await expect(
         server.tools.get(name)!.handler({ label: "L", value: 1 }),
@@ -56,7 +57,7 @@ describe("picklist location XOR validation", () => {
     it(`${name}: throws when Local pair is incomplete (entity only)`, async () => {
       const server = createMockServer();
       const client = { post: vi.fn(), get: vi.fn() } as any;
-      registerPicklistTools(server as any, client);
+      registerPicklistTools(server as any, client, true);
 
       await expect(
         server.tools.get(name)!.handler({
@@ -195,10 +196,10 @@ describe("update_picklist_option", () => {
 });
 
 describe("delete_picklist_option", () => {
-  it("posts DeleteOptionValue with Value and location", async () => {
+  it("posts DeleteOptionValue with Value and location when allowDelete is true", async () => {
     const server = createMockServer();
     const client = { post: vi.fn().mockResolvedValue({}) } as any;
-    registerPicklistTools(server as any, client);
+    registerPicklistTools(server as any, client, true);
 
     const result = await server.tools
       .get("delete_picklist_option")!
@@ -215,11 +216,28 @@ describe("delete_picklist_option", () => {
     expect(result.content[0].text).toContain("deleted successfully");
   });
 
-  it("description warns about orphan values", async () => {
+  it("description warns about orphan values when allowDelete is true", async () => {
     const server = createMockServer();
-    registerPicklistTools(server as any, { post: vi.fn() } as any);
+    registerPicklistTools(server as any, { post: vi.fn() } as any, true);
     const tool = server.tools.get("delete_picklist_option")!;
     expect(tool.description.toLowerCase()).toContain("orphan");
+  });
+
+  it("returns isError when allowDelete is false (default)", async () => {
+    const server = createMockServer();
+    const client = { post: vi.fn() } as any;
+    registerPicklistTools(server as any, client);
+
+    const tool = server.tools.get("delete_picklist_option")!;
+    expect(tool.description).toContain("disabled");
+
+    const result = await tool.handler({
+      option_set_name: "MyGlobalSet",
+      value: 909890009,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("DATAVERSE_ALLOW_DELETE");
+    expect(client.post).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
Make all three destructive tools share the same safety flag:
- \`delete_record\` — already gated
- \`delete_attribute\` — already gated (PR #17)
- **\`delete_picklist_option\`** — now gated too

Previously \`delete_picklist_option\` was unconditionally registered. This was inconsistent with the rest of the codebase and surprising for users who set \`DATAVERSE_ALLOW_DELETE=true\` expecting a single switch for destructive operations.

## Why

Deleting an option does not erase row data, but it leaves every record holding the option's integer value with an orphan number:
- No label in the UI
- Reports grouping by that option break silently
- Workflow rules keyed on specific status values can mismatch

By impact it sits closer to \`delete_attribute\` than to a read-only operation — reasonable to require the same deliberate opt-in.

## Behaviour
When \`allowDelete\` is false (default), \`delete_picklist_option\` registers as a stub that returns \`isError\` with an instructional message — same pattern as \`delete_record\` and \`delete_attribute\`.

## Breaking change note
This changes the default behaviour of an existing tool. The package has not been published to npm, so no external users are affected. Existing local configs that rely on deleting options without the flag will now get the instructional error; the fix is a one-line env var addition.

## Test plan
- [x] \`npm run lint\` / \`npm run build\` clean
- [x] 78 unit tests pass (+1 new): stub returns isError + matching description, client.post is not invoked
- [x] Existing XOR-validation tests updated to register with \`allowDelete=true\` so the real handler (with validation) is exercised

🤖 Generated with [Claude Code](https://claude.com/claude-code)