### PR TITLE
Fix update_attribute HTTP 405: use PUT with GET+merge, not PATCH

### DIFF
--- a/src/tools/schema-tools.ts
+++ b/src/tools/schema-tools.ts
@@ -503,6 +503,12 @@ export function registerSchemaTools(
       if (params.max_value !== undefined) merged.MaxValue = params.max_value;
       if (params.precision !== undefined) merged.Precision = params.precision;
 
+      // Dataverse metadata API does NOT expose ETags (verified empirically
+      // with odata.metadata=full — neither ETag response header nor
+      // @odata.etag body property is present), so optimistic concurrency via
+      // If-Match: <etag> is not available here. If-Match: * is what Microsoft's
+      // own update-column example uses — it signals "update existing" (vs
+      // upsert) without tying to a version.
       const headers: Record<string, string> = { "If-Match": "*" };
       if (params.merge_labels) headers["MSCRM.MergeLabels"] = "true";
 

--- a/src/tools/schema-tools.ts
+++ b/src/tools/schema-tools.ts
@@ -465,13 +465,20 @@ export function registerSchemaTools(
 
       const entityEscaped = escapeODataString(params.entity_logical_name);
       const attrEscaped = escapeODataString(params.attribute_logical_name);
-      const path = `/EntityDefinitions(LogicalName='${entityEscaped}')/Attributes(LogicalName='${attrEscaped}')`;
+      const odataType = ATTRIBUTE_ODATA_TYPE_MAP[params.type];
+      const basePath = `/EntityDefinitions(LogicalName='${entityEscaped}')/Attributes(LogicalName='${attrEscaped}')`;
+      // GET must be cast to the concrete derived type — otherwise the response
+      // only contains base AttributeMetadata fields and type-specific ones
+      // (MaxLength, Precision, Format, OptionSet, …) are missing. A subsequent
+      // PUT with those fields absent would either 400 or reset them, because
+      // PUT replaces the full resource.
+      const getPath = `${basePath}/${odataType}`;
 
       // Dataverse metadata endpoint rejects PATCH with HTTP 405; updates go
       // through PUT, which REPLACES the full resource. To avoid resetting
-      // untouched fields (RequiredLevel, MaxLength, etc.) to defaults, fetch
-      // current metadata first and merge the user-supplied changes on top.
-      const current = (await client.get(path)) as Record<string, unknown>;
+      // untouched fields to defaults, fetch current metadata (with the type
+      // cast) and merge the user-supplied changes on top.
+      const current = (await client.get(getPath)) as Record<string, unknown>;
       const merged: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(current)) {
         // Strip control metadata (@odata.etag, @odata.context, ...) — the
@@ -479,7 +486,7 @@ export function registerSchemaTools(
         if (key.startsWith("@odata.")) continue;
         merged[key] = value;
       }
-      merged["@odata.type"] = ATTRIBUTE_ODATA_TYPE_MAP[params.type];
+      merged["@odata.type"] = odataType;
 
       const lang = params.language_code ?? 1033;
       if (params.display_name !== undefined) {
@@ -499,7 +506,7 @@ export function registerSchemaTools(
       const headers: Record<string, string> = { "If-Match": "*" };
       if (params.merge_labels) headers["MSCRM.MergeLabels"] = "true";
 
-      await client.request(path, { method: "PUT", body: merged, headers });
+      await client.request(basePath, { method: "PUT", body: merged, headers });
       return {
         content: [
           {

--- a/src/tools/schema-tools.ts
+++ b/src/tools/schema-tools.ts
@@ -463,33 +463,43 @@ export function registerSchemaTools(
         };
       }
 
-      const body: Record<string, unknown> = {
-        "@odata.type": ATTRIBUTE_ODATA_TYPE_MAP[params.type],
-      };
-      const lang = params.language_code ?? 1033;
-      if (params.display_name !== undefined) {
-        body.DisplayName = buildLabel(params.display_name, lang);
-      }
-      if (params.description !== undefined) {
-        body.Description = buildLabel(params.description, lang);
-      }
-      if (params.required !== undefined) {
-        body.RequiredLevel = { Value: params.required };
-      }
-      if (params.max_length !== undefined) body.MaxLength = params.max_length;
-      if (params.min_value !== undefined) body.MinValue = params.min_value;
-      if (params.max_value !== undefined) body.MaxValue = params.max_value;
-      if (params.precision !== undefined) body.Precision = params.precision;
-
-      const headers: Record<string, string> = {};
-      if (params.merge_labels) headers["MSCRM.MergeLabels"] = "true";
-
       const entityEscaped = escapeODataString(params.entity_logical_name);
       const attrEscaped = escapeODataString(params.attribute_logical_name);
-      await client.request(
-        `/EntityDefinitions(LogicalName='${entityEscaped}')/Attributes(LogicalName='${attrEscaped}')`,
-        { method: "PATCH", body, headers },
-      );
+      const path = `/EntityDefinitions(LogicalName='${entityEscaped}')/Attributes(LogicalName='${attrEscaped}')`;
+
+      // Dataverse metadata endpoint rejects PATCH with HTTP 405; updates go
+      // through PUT, which REPLACES the full resource. To avoid resetting
+      // untouched fields (RequiredLevel, MaxLength, etc.) to defaults, fetch
+      // current metadata first and merge the user-supplied changes on top.
+      const current = (await client.get(path)) as Record<string, unknown>;
+      const merged: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(current)) {
+        // Strip control metadata (@odata.etag, @odata.context, ...) — the
+        // discriminator @odata.type is re-set below.
+        if (key.startsWith("@odata.")) continue;
+        merged[key] = value;
+      }
+      merged["@odata.type"] = ATTRIBUTE_ODATA_TYPE_MAP[params.type];
+
+      const lang = params.language_code ?? 1033;
+      if (params.display_name !== undefined) {
+        merged.DisplayName = buildLabel(params.display_name, lang);
+      }
+      if (params.description !== undefined) {
+        merged.Description = buildLabel(params.description, lang);
+      }
+      if (params.required !== undefined) {
+        merged.RequiredLevel = { Value: params.required };
+      }
+      if (params.max_length !== undefined) merged.MaxLength = params.max_length;
+      if (params.min_value !== undefined) merged.MinValue = params.min_value;
+      if (params.max_value !== undefined) merged.MaxValue = params.max_value;
+      if (params.precision !== undefined) merged.Precision = params.precision;
+
+      const headers: Record<string, string> = { "If-Match": "*" };
+      if (params.merge_labels) headers["MSCRM.MergeLabels"] = "true";
+
+      await client.request(path, { method: "PUT", body: merged, headers });
       return {
         content: [
           {

--- a/tests/schema-tools.test.ts
+++ b/tests/schema-tools.test.ts
@@ -238,6 +238,9 @@ describe("update_attribute", () => {
     const [putPath, opts] = client.request.mock.calls[0];
     expect(putPath).toBe(basePath);
     expect(opts.method).toBe("PUT");
+    // Dataverse metadata API does not expose ETags, so optimistic concurrency
+    // via If-Match: <etag> isn't possible. Use "*" (matches Microsoft's own
+    // docs example).
     expect(opts.headers["If-Match"]).toBe("*");
     expect(result.content[0].text).toContain("updated successfully");
   });
@@ -371,6 +374,8 @@ describe("update_attribute", () => {
     // base fields + String-specific MaxLength and Format.
     const stringAttr = {
       ...existingAttribute,
+      LogicalName: "fundai_email",
+      SchemaName: "Fundai_email",
       "@odata.type": "#Microsoft.Dynamics.CRM.StringAttributeMetadata",
       MaxLength: 500,
       Format: "Email",
@@ -399,6 +404,11 @@ describe("update_attribute", () => {
     const server = createMockServer();
     const client = mockClient({
       ...existingAttribute,
+      // Identity fields must match the URL the handler is called with,
+      // otherwise the test would pass even if the implementation PUT a body
+      // whose identity didn't match (which would be a real bug).
+      LogicalName: "fundai_amount",
+      SchemaName: "Fundai_amount",
       "@odata.type": "#Microsoft.Dynamics.CRM.DecimalAttributeMetadata",
       Precision: 2,
       MinValue: -1000,
@@ -419,6 +429,8 @@ describe("update_attribute", () => {
     expect(opts.body["@odata.type"]).toBe(
       "Microsoft.Dynamics.CRM.DecimalAttributeMetadata",
     );
+    expect(opts.body.LogicalName).toBe("fundai_amount");
+    expect(opts.body.SchemaName).toBe("Fundai_amount");
     expect(opts.body.MinValue).toBe(0);
     expect(opts.body.MaxValue).toBe(9999);
     expect(opts.body.Precision).toBe(4);

--- a/tests/schema-tools.test.ts
+++ b/tests/schema-tools.test.ts
@@ -266,7 +266,9 @@ describe("update_attribute", () => {
       });
 
       const getPath = client.get.mock.calls[0][0] as string;
-      expect(getPath).toMatch(new RegExp(`/${odataType}$`));
+      // Literal suffix check — RegExp would treat the dots in the odataType
+      // as wildcards and pass on false positives.
+      expect(getPath.endsWith(`/${odataType}`)).toBe(true);
     }
   });
 

--- a/tests/schema-tools.test.ts
+++ b/tests/schema-tools.test.ts
@@ -213,7 +213,7 @@ describe("update_attribute", () => {
     } as any;
   }
 
-  it("fetches current metadata and PUTs the merged body with If-Match: *", async () => {
+  it("GETs with the concrete type cast and PUTs the base path with If-Match: *", async () => {
     const server = createMockServer();
     const client = mockClient();
     registerSchemaTools(server as any, client);
@@ -225,16 +225,46 @@ describe("update_attribute", () => {
       display_name: "Settled At",
     });
 
-    const expectedPath =
+    const basePath =
       "/EntityDefinitions(LogicalName='fundai_x')/Attributes(LogicalName='fundai_settledat')";
-    expect(client.get).toHaveBeenCalledWith(expectedPath);
+    // GET must target the concrete derived-type cast — without it, type-specific
+    // fields (MaxLength, Format, …) are missing from the response and would be
+    // dropped from the PUT body, breaking the merge.
+    expect(client.get).toHaveBeenCalledWith(
+      `${basePath}/Microsoft.Dynamics.CRM.StringAttributeMetadata`,
+    );
 
     expect(client.request).toHaveBeenCalledTimes(1);
     const [putPath, opts] = client.request.mock.calls[0];
-    expect(putPath).toBe(expectedPath);
+    expect(putPath).toBe(basePath);
     expect(opts.method).toBe("PUT");
     expect(opts.headers["If-Match"]).toBe("*");
     expect(result.content[0].text).toContain("updated successfully");
+  });
+
+  it("uses the correct cast for each attribute type", async () => {
+    for (const [userType, odataType] of [
+      ["Integer", "Microsoft.Dynamics.CRM.IntegerAttributeMetadata"],
+      ["Decimal", "Microsoft.Dynamics.CRM.DecimalAttributeMetadata"],
+      ["Money", "Microsoft.Dynamics.CRM.MoneyAttributeMetadata"],
+      ["DateTime", "Microsoft.Dynamics.CRM.DateTimeAttributeMetadata"],
+      ["Boolean", "Microsoft.Dynamics.CRM.BooleanAttributeMetadata"],
+      ["Picklist", "Microsoft.Dynamics.CRM.PicklistAttributeMetadata"],
+    ] as const) {
+      const server = createMockServer();
+      const client = mockClient();
+      registerSchemaTools(server as any, client);
+
+      await server.tools.get("update_attribute")!.handler({
+        entity_logical_name: "fundai_x",
+        attribute_logical_name: "fundai_col",
+        type: userType,
+        display_name: "X",
+      });
+
+      const getPath = client.get.mock.calls[0][0] as string;
+      expect(getPath).toMatch(new RegExp(`/${odataType}$`));
+    }
   });
 
   it("strips @odata.etag/@odata.context but keeps everything else from GET (merge preserves untouched fields)", async () => {
@@ -333,6 +363,36 @@ describe("update_attribute", () => {
     expect(result.content[0].text).toContain("at least one of");
     expect(client.get).not.toHaveBeenCalled();
     expect(client.request).not.toHaveBeenCalled();
+  });
+
+  it("preserves type-specific fields from the cast GET (MaxLength/Format for String)", async () => {
+    const server = createMockServer();
+    // Simulates what a cast GET to .../StringAttributeMetadata returns:
+    // base fields + String-specific MaxLength and Format.
+    const stringAttr = {
+      ...existingAttribute,
+      "@odata.type": "#Microsoft.Dynamics.CRM.StringAttributeMetadata",
+      MaxLength: 500,
+      Format: "Email",
+      FormatName: { Value: "Email" },
+    };
+    const client = mockClient(stringAttr as any);
+    registerSchemaTools(server as any, client);
+
+    // User only changes display_name — MaxLength/Format MUST survive.
+    await server.tools.get("update_attribute")!.handler({
+      entity_logical_name: "fundai_x",
+      attribute_logical_name: "fundai_email",
+      type: "String",
+      display_name: "Email",
+    });
+
+    const [, opts] = client.request.mock.calls[0];
+    expect(opts.body.MaxLength).toBe(500);
+    expect(opts.body.Format).toBe("Email");
+    expect(opts.body.FormatName).toEqual({ Value: "Email" });
+    // user-supplied override still wins
+    expect(opts.body.DisplayName.LocalizedLabels[0].Label).toBe("Email");
   });
 
   it("forwards numeric bounds and precision via merge", async () => {

--- a/tests/schema-tools.test.ts
+++ b/tests/schema-tools.test.ts
@@ -190,9 +190,32 @@ describe("buildAttributeBody", () => {
 });
 
 describe("update_attribute", () => {
-  it("PATCHes only the provided fields with the correct @odata.type", async () => {
+  const existingAttribute = {
+    "@odata.context": "https://org/api/data/v9.2/$metadata#EntityDefinitions(...)/Attributes/$entity",
+    "@odata.etag": 'W/"12345"',
+    "@odata.type": "#Microsoft.Dynamics.CRM.StringAttributeMetadata",
+    MetadataId: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    LogicalName: "fundai_settledat",
+    SchemaName: "Fundai_settledat",
+    EntityLogicalName: "fundai_x",
+    MaxLength: 200,
+    RequiredLevel: { Value: "ApplicationRequired" },
+    IsCustomAttribute: true,
+    DisplayName: {
+      LocalizedLabels: [{ Label: "Old Name", LanguageCode: 1033 }],
+    },
+  };
+
+  function mockClient(current = existingAttribute) {
+    return {
+      get: vi.fn().mockResolvedValue(current),
+      request: vi.fn().mockResolvedValue({}),
+    } as any;
+  }
+
+  it("fetches current metadata and PUTs the merged body with If-Match: *", async () => {
     const server = createMockServer();
-    const client = { request: vi.fn().mockResolvedValue({}) } as any;
+    const client = mockClient();
     registerSchemaTools(server as any, client);
 
     const result = await server.tools.get("update_attribute")!.handler({
@@ -200,33 +223,76 @@ describe("update_attribute", () => {
       attribute_logical_name: "fundai_settledat",
       type: "String",
       display_name: "Settled At",
-      required: "None",
     });
 
+    const expectedPath =
+      "/EntityDefinitions(LogicalName='fundai_x')/Attributes(LogicalName='fundai_settledat')";
+    expect(client.get).toHaveBeenCalledWith(expectedPath);
+
     expect(client.request).toHaveBeenCalledTimes(1);
-    const [path, opts] = client.request.mock.calls[0];
-    expect(path).toBe(
-      "/EntityDefinitions(LogicalName='fundai_x')/Attributes(LogicalName='fundai_settledat')",
-    );
-    expect(opts.method).toBe("PATCH");
-    expect(opts.body["@odata.type"]).toBe(
-      "Microsoft.Dynamics.CRM.StringAttributeMetadata",
-    );
-    expect(opts.body.DisplayName.LocalizedLabels[0].Label).toBe("Settled At");
-    expect(opts.body.RequiredLevel).toEqual({ Value: "None" });
-    expect(opts.body.Description).toBeUndefined();
-    expect(opts.body.MaxLength).toBeUndefined();
+    const [putPath, opts] = client.request.mock.calls[0];
+    expect(putPath).toBe(expectedPath);
+    expect(opts.method).toBe("PUT");
+    expect(opts.headers["If-Match"]).toBe("*");
     expect(result.content[0].text).toContain("updated successfully");
   });
 
-  it("sends MSCRM.MergeLabels header when merge_labels=true", async () => {
+  it("strips @odata.etag/@odata.context but keeps everything else from GET (merge preserves untouched fields)", async () => {
     const server = createMockServer();
-    const client = { request: vi.fn().mockResolvedValue({}) } as any;
+    const client = mockClient();
     registerSchemaTools(server as any, client);
 
     await server.tools.get("update_attribute")!.handler({
       entity_logical_name: "fundai_x",
-      attribute_logical_name: "fundai_col",
+      attribute_logical_name: "fundai_settledat",
+      type: "String",
+      display_name: "Settled At",
+    });
+
+    const [, opts] = client.request.mock.calls[0];
+    // discriminator reset to the plain @odata.type form expected by PUT
+    expect(opts.body["@odata.type"]).toBe(
+      "Microsoft.Dynamics.CRM.StringAttributeMetadata",
+    );
+    // control metadata stripped
+    expect(opts.body["@odata.etag"]).toBeUndefined();
+    expect(opts.body["@odata.context"]).toBeUndefined();
+    // untouched fields preserved from GET
+    expect(opts.body.MetadataId).toBe("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    expect(opts.body.MaxLength).toBe(200);
+    expect(opts.body.RequiredLevel).toEqual({ Value: "ApplicationRequired" });
+    expect(opts.body.IsCustomAttribute).toBe(true);
+    expect(opts.body.SchemaName).toBe("Fundai_settledat");
+    // user-supplied field overrides
+    expect(opts.body.DisplayName.LocalizedLabels[0].Label).toBe("Settled At");
+  });
+
+  it("user-supplied fields override values from GET", async () => {
+    const server = createMockServer();
+    const client = mockClient();
+    registerSchemaTools(server as any, client);
+
+    await server.tools.get("update_attribute")!.handler({
+      entity_logical_name: "fundai_x",
+      attribute_logical_name: "fundai_settledat",
+      type: "String",
+      required: "None",
+      max_length: 500,
+    });
+
+    const [, opts] = client.request.mock.calls[0];
+    expect(opts.body.RequiredLevel).toEqual({ Value: "None" }); // was ApplicationRequired
+    expect(opts.body.MaxLength).toBe(500); // was 200
+  });
+
+  it("sends MSCRM.MergeLabels header when merge_labels=true", async () => {
+    const server = createMockServer();
+    const client = mockClient();
+    registerSchemaTools(server as any, client);
+
+    await server.tools.get("update_attribute")!.handler({
+      entity_logical_name: "fundai_x",
+      attribute_logical_name: "fundai_settledat",
       type: "String",
       display_name: "Localized",
       merge_labels: true,
@@ -234,16 +300,17 @@ describe("update_attribute", () => {
 
     const [, opts] = client.request.mock.calls[0];
     expect(opts.headers["MSCRM.MergeLabels"]).toBe("true");
+    expect(opts.headers["If-Match"]).toBe("*");
   });
 
   it("does not send MSCRM.MergeLabels header by default", async () => {
     const server = createMockServer();
-    const client = { request: vi.fn().mockResolvedValue({}) } as any;
+    const client = mockClient();
     registerSchemaTools(server as any, client);
 
     await server.tools.get("update_attribute")!.handler({
       entity_logical_name: "fundai_x",
-      attribute_logical_name: "fundai_col",
+      attribute_logical_name: "fundai_settledat",
       type: "String",
       display_name: "Replaced",
     });
@@ -252,9 +319,9 @@ describe("update_attribute", () => {
     expect(opts.headers["MSCRM.MergeLabels"]).toBeUndefined();
   });
 
-  it("returns isError when no mutable fields are provided (no-op PATCH guard)", async () => {
+  it("returns isError when no mutable fields are provided (no-op guard); no HTTP calls made", async () => {
     const server = createMockServer();
-    const client = { request: vi.fn() } as any;
+    const client = mockClient();
     registerSchemaTools(server as any, client);
 
     const result = await server.tools.get("update_attribute")!.handler({
@@ -264,12 +331,19 @@ describe("update_attribute", () => {
     });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("at least one of");
+    expect(client.get).not.toHaveBeenCalled();
     expect(client.request).not.toHaveBeenCalled();
   });
 
-  it("forwards numeric bounds and precision", async () => {
+  it("forwards numeric bounds and precision via merge", async () => {
     const server = createMockServer();
-    const client = { request: vi.fn().mockResolvedValue({}) } as any;
+    const client = mockClient({
+      ...existingAttribute,
+      "@odata.type": "#Microsoft.Dynamics.CRM.DecimalAttributeMetadata",
+      Precision: 2,
+      MinValue: -1000,
+      MaxValue: 1000,
+    } as any);
     registerSchemaTools(server as any, client);
 
     await server.tools.get("update_attribute")!.handler({
@@ -277,7 +351,7 @@ describe("update_attribute", () => {
       attribute_logical_name: "fundai_amount",
       type: "Decimal",
       min_value: 0,
-      max_value: 1000,
+      max_value: 9999,
       precision: 4,
     });
 
@@ -286,7 +360,7 @@ describe("update_attribute", () => {
       "Microsoft.Dynamics.CRM.DecimalAttributeMetadata",
     );
     expect(opts.body.MinValue).toBe(0);
-    expect(opts.body.MaxValue).toBe(1000);
+    expect(opts.body.MaxValue).toBe(9999);
     expect(opts.body.Precision).toBe(4);
   });
 });


### PR DESCRIPTION
Closes #18.

## Problem
\`update_attribute\` returned HTTP 405 on every call:
> "The requested resource does not support http method 'PATCH'."

Dataverse metadata endpoint for Attributes does not accept PATCH — updates must go through PUT. But PUT **replaces** the whole resource, so sending only the user-supplied diff would reset every untouched field (\`RequiredLevel\`, \`MaxLength\`, etc.) to defaults.

## Fix
Three-step flow per \`update_attribute\` call:

1. \`GET\` current attribute metadata from \`/EntityDefinitions(LogicalName='X')/Attributes(LogicalName='Y')\`
2. Strip control metadata (\`@odata.etag\`, \`@odata.context\`) from the response, preserve everything else (\`MetadataId\`, \`SchemaName\`, \`RequiredLevel\`, …). Overlay user-supplied fields on top. Reset the \`@odata.type\` discriminator to the plain form required by PUT.
3. \`PUT\` the merged body to the same path with:
   - \`If-Match: *\` — mark as update, not upsert
   - \`MSCRM.MergeLabels: true\` — only when \`merge_labels=true\` was passed (preserves other-language labels)

## Test plan
- [x] \`npm run lint\` / \`npm run build\` clean
- [x] 79 unit tests pass (+3 new, −1 obsolete): PUT path + If-Match + control-metadata stripping + untouched-field preservation + user-override-wins + MergeLabels on/off + no-op guard + numeric bound merge
- [ ] Post-restart end-to-end verification against the live \`fundai_achtransaction\` table (the two renames + one description update from the CRM re-design table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

@codex