### PR TITLE
Prepare package for npm publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,23 @@ MCP (Model Context Protocol) server for Microsoft Dataverse API with [safe-by-de
 
 Picklist tools accept either `entity_logical_name` + `attribute_logical_name` (Local OptionSet) or `option_set_name` (Global OptionSet) — the two modes are mutually exclusive. Write operations require Customizer or System Administrator role on the connected service principal. Deleting an option does **not** update existing records that hold its numeric value — they are left with an orphan integer.
 
+## Quick start (no clone)
+
+Add to `.mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "dataverse": {
+      "command": "npx",
+      "args": ["-y", "dataverse-mcp-server"]
+    }
+  }
+}
+```
+
+Create a `.env` file next to it with the four required variables (see [Environment variables](#environment-variables) below) and restart your MCP client. The `-y` flag tells `npx` to auto-confirm the package install.
+
 ## Setup
 
 ### Environment variables
@@ -67,9 +84,9 @@ npm install
 npm run build
 ```
 
-### Claude Code configuration
+### Claude Code configuration (local build)
 
-Add `.mcp.json` to your project root:
+If you cloned the repo instead of using `npx`:
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
   "bin": {
     "dataverse-mcp-server": "dist/index.js"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "engines": {
     "node": ">=18"
   },
@@ -17,15 +22,27 @@
     "lint:fix": "biome check --write src/",
     "test": "vitest run",
     "test:watch": "vitest",
-    "prepare": "husky"
+    "prepare": "husky",
+    "prepublishOnly": "npm run lint && npm test && npm run build"
   },
   "keywords": [
     "mcp",
+    "model-context-protocol",
     "dataverse",
     "dynamics365",
-    "microsoft"
+    "power-platform",
+    "microsoft",
+    "claude"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rededis/dataverse-mcp-server.git"
+  },
+  "bugs": {
+    "url": "https://github.com/rededis/dataverse-mcp-server/issues"
+  },
+  "homepage": "https://github.com/rededis/dataverse-mcp-server#readme",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "dotenv": "^17.4.1",


### PR DESCRIPTION
Closes #12.

## Summary
Make the package publishable to npm without shipping everything in the repo.

- **\`files\` field** — \`["dist", "README.md", "LICENSE"]\`. Empirically verified via \`npm pack --dry-run\`: tarball shrinks from 41 files / 200KB unpacked to 21 files / 98KB, and no longer includes \`src/\`, \`tests/\`, \`.claude/\` (local dev settings!), \`.github/workflows/\`, \`.husky/\`, \`.mcp.json\`, \`biome.json\`, \`tsconfig.json\`.
- **\`prepublishOnly\` hook** — lint + test + build must pass before \`npm publish\` succeeds. Safeguard against shipping a stale \`dist/\`.
- **Metadata** — \`repository\` / \`bugs\` / \`homepage\` for the npm package page. Broadened keywords (model-context-protocol, power-platform, claude).
- **README** — new "Quick start (no clone)" section with the npx-based \`.mcp.json\` snippet. Existing local-build snippet renamed to "Claude Code configuration (local build)" for clarity.

## Why this matters
Attempted \`npm publish\` from main without these changes would have:
1. Published the repo contributor's personal \`.claude/settings.local.json\` to the public registry (privacy leak)
2. Included 50KB of TypeScript source and 50KB of tests — useless weight for consumers
3. Had no way to catch a stale \`dist/\` before publishing

## Test plan
- [x] \`npm pack --dry-run\` shows exactly: \`LICENSE\`, \`README.md\`, \`package.json\`, and all files under \`dist/\` (21 files, 22KB packed / 98KB unpacked)
- [x] \`npm run lint\` / \`npm run build\` / \`npm test\` clean — all 82 unit tests pass
- [ ] After merge: \`npm publish\` from main (once 2FA is enabled on the npm account)

🤖 Generated with [Claude Code](https://claude.com/claude-code)