### PR TITLE
Prepare package for npm publish under @rededis scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,23 @@ MCP (Model Context Protocol) server for Microsoft Dataverse API with [safe-by-de
 
 Picklist tools accept either `entity_logical_name` + `attribute_logical_name` (Local OptionSet) or `option_set_name` (Global OptionSet) — the two modes are mutually exclusive. Write operations require Customizer or System Administrator role on the connected service principal. Deleting an option does **not** update existing records that hold its numeric value — they are left with an orphan integer.
 
+## Quick start (no clone)
+
+Add to `.mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "dataverse": {
+      "command": "npx",
+      "args": ["-y", "@rededis/dataverse-mcp-server"]
+    }
+  }
+}
+```
+
+Create a `.env` file next to it with the four required variables (see [Environment variables](#environment-variables) below) and restart your MCP client. The `-y` flag tells `npx` to auto-confirm the package install.
+
 ## Setup
 
 ### Environment variables
@@ -67,9 +84,9 @@ npm install
 npm run build
 ```
 
-### Claude Code configuration
+### Claude Code configuration (local build)
 
-Add `.mcp.json` to your project root:
+If you cloned the repo instead of using `npx`:
 
 ```json
 {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "files": [
     "dist",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    ".env.example"
   ],
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -1,11 +1,16 @@
 {
-  "name": "dataverse-mcp-server",
+  "name": "@rededis/dataverse-mcp-server",
   "version": "0.1.0",
   "description": "MCP server for Microsoft Dataverse API",
   "main": "dist/index.js",
   "bin": {
     "dataverse-mcp-server": "dist/index.js"
   },
+  "files": [
+    "dist",
+    "README.md",
+    "LICENSE"
+  ],
   "engines": {
     "node": ">=18"
   },
@@ -17,15 +22,30 @@
     "lint:fix": "biome check --write src/",
     "test": "vitest run",
     "test:watch": "vitest",
-    "prepare": "husky"
+    "prepare": "husky",
+    "prepublishOnly": "npm run lint && npm test && npm run build"
   },
   "keywords": [
     "mcp",
+    "model-context-protocol",
     "dataverse",
     "dynamics365",
-    "microsoft"
+    "power-platform",
+    "microsoft",
+    "claude"
   ],
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rededis/dataverse-mcp-server.git"
+  },
+  "bugs": {
+    "url": "https://github.com/rededis/dataverse-mcp-server/issues"
+  },
+  "homepage": "https://github.com/rededis/dataverse-mcp-server#readme",
+  "publishConfig": {
+    "access": "public"
+  },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.1",
     "dotenv": "^17.4.1",


### PR DESCRIPTION
Supersedes #21 (unscoped variant).

Closes #12.

## Why scoped
Publishing as \`@rededis/dataverse-mcp-server\` so the scope can host any future MCP or utility package under one namespace, matching how \`@vercel/*\`, \`@tanstack/*\`, \`@modelcontextprotocol/*\` ship families of related tools. Bonus: fits the granular npm access token I already generated (scope-bound to \`@rededis\`) without needing a "bootstrap" broad token + rotation dance.

## Changes

**\`package.json\`:**
- \`name\` → \`@rededis/dataverse-mcp-server\`
- \`publishConfig.access: public\` — scoped packages are private by default; this one-time setting means we never need \`--access public\` on publish
- \`files: ["dist", "README.md", "LICENSE"]\` — without it the tarball includes \`src/\`, \`tests/\`, \`.claude/\` (local dev settings!), \`.github/\`, \`biome.json\`, \`tsconfig.json\` (41 files / 200KB). After: **21 files / 98.5KB**.
- \`prepublishOnly\` hook: \`lint && test && build\` must pass before publish
- \`repository\` / \`bugs\` / \`homepage\` for the npm page
- Broadened keywords (model-context-protocol, power-platform, claude)

**\`README.md\`:**
- New "Quick start (no clone)" section — npx-based \`.mcp.json\` snippet with the scoped name
- Existing local-node snippet renamed "Claude Code configuration (local build)" for clarity

## User-facing note
Bin command stays \`dataverse-mcp-server\` — unchanged. Only the registry name becomes scoped. Consumers do:
\`\`\`json
"args": ["-y", "@rededis/dataverse-mcp-server"]
\`\`\`
Global install still gives \`dataverse-mcp-server\` on \$PATH.

## Test plan
- [x] \`npm run lint\` / \`npm run build\` / \`npm test\` clean — all 82 tests pass via \`prepublishOnly\`
- [x] \`npm pack --dry-run\` shows \`name: @rededis/dataverse-mcp-server\`, 21 files, 22.1KB packed / 98.5KB unpacked; no \`src/\`, \`tests/\`, \`.claude/\`, \`.github/\`, etc.
- [ ] After merge: \`npm publish\` with the existing \`@rededis\`-scoped token (no rotation needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)