### PR TITLE
Release 0.1.2: add shields.io badges to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2026-04-24
+
+### Added
+
+- Shields.io badges in README (npm version, monthly downloads, CI status, Node.js engines, TypeScript version, license). They update automatically as the package evolves — no manual version tweaks.
+
 ## [0.1.1] - 2026-04-24
 
 ### Added
@@ -65,6 +71,7 @@ All picklist tools accept either `entity_logical_name` + `attribute_logical_name
 - Dataverse Web API v9.2 with OAuth 2.0 client-credentials authentication
 - Supports `@odata.nextLink` pagination for large solutions
 
-[Unreleased]: https://github.com/rededis/dataverse-mcp-server/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/rededis/dataverse-mcp-server/compare/v0.1.2...HEAD
+[0.1.2]: https://github.com/rededis/dataverse-mcp-server/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/rededis/dataverse-mcp-server/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/rededis/dataverse-mcp-server/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # dataverse-mcp-server
 
+[![npm version](https://img.shields.io/npm/v/@rededis/dataverse-mcp-server.svg)](https://www.npmjs.com/package/@rededis/dataverse-mcp-server)
+[![npm downloads](https://img.shields.io/npm/dm/@rededis/dataverse-mcp-server.svg)](https://www.npmjs.com/package/@rededis/dataverse-mcp-server)
+[![CI](https://github.com/rededis/dataverse-mcp-server/actions/workflows/ci.yml/badge.svg)](https://github.com/rededis/dataverse-mcp-server/actions/workflows/ci.yml)
+[![Node.js](https://img.shields.io/node/v/@rededis/dataverse-mcp-server.svg)](https://nodejs.org)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.7-3178C6.svg)](https://www.typescriptlang.org)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](./LICENSE)
+
 MCP (Model Context Protocol) server for Microsoft Dataverse API with [safe-by-default](#safety) configuration. Works with any Dataverse / Dynamics 365 environment.
 
 ## Tools

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rededis/dataverse-mcp-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rededis/dataverse-mcp-server",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rededis/dataverse-mcp-server",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MCP server for Microsoft Dataverse API",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary
Add shields.io badges to the top of README (under the H1 title): npm version, monthly downloads, CI status, Node.js engines, TypeScript version, license. Matches the standard-issue badge strip that makes a README's provenance readable at a glance.

## Auto-update behaviour
- **npm version** — reads the current latest tag from the npm registry; updates on every publish with no README change needed
- **npm downloads** — monthly figure from npm-stats; will read \`0\` for a couple of weeks until npm-stat starts tracking the new package
- **CI** — \`passing\`/\`failing\` from the last run of \`.github/workflows/ci.yml\`
- **Node.js** — derives from the \`engines.node\` field in \`package.json\` (currently \`>=18\`)
- **TypeScript** — hardcoded to \`5.7\` (shields.io has no automatic source for dev-deps); bump manually when major TypeScript version changes
- **License** — static MIT badge linking to \`./LICENSE\`

## Version bump
- \`package.json\` → 0.1.2
- \`package-lock.json\` regenerated via \`npm install\`
- \`CHANGELOG.md\` entry added

## Test plan
- [x] \`npm run lint\` / \`npm run build\` / \`npm test\` clean via \`prepublishOnly\`
- [ ] After merge: \`npm publish\` → 0.1.2, tag, release with \`--generate-notes\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)