### PR TITLE
Release 0.2.0: DateTime Format and Behavior for add/update_attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-24
+
+### Added
+
+- `add_attribute` and `update_attribute` accept two new optional fields for `DateTime` attributes (closes #24):
+  - `date_format`: `"DateOnly" | "DateAndTime"` — controls UI presentation (calendar-only vs date+time picker). Maps to `Format` in the OData body.
+  - `date_behavior`: `"UserLocal" | "DateOnly" | "TimeZoneIndependent"` — controls storage/projection semantics. Maps to `DateTimeBehavior: { Value: ... }` (wrapped form is a Dataverse gotcha).
+- Client-side validation before any HTTP call:
+  - `date_format: "DateOnly"` requires `date_behavior: "DateOnly"` — mismatched pairs rejected with a clear message.
+  - `date_format` / `date_behavior` on a non-DateTime type rejected.
+- Tool descriptions surface the one-way nature of Dataverse `DateTimeBehavior` mutations so the model warns users before calling `update_attribute` on a behavior-locked column.
+
+### Why minor bump (0.2.0, not 0.1.3)
+
+`AttributeSchema` gained two public fields — new schema surface exposed to MCP clients. Strict semver reads this as a minor addition, not a patch. Backward compatible: existing `add_attribute` / `update_attribute` calls without the new fields behave identically to 0.1.x.
+
 ## [0.1.2] - 2026-04-24
 
 ### Added
@@ -71,7 +87,8 @@ All picklist tools accept either `entity_logical_name` + `attribute_logical_name
 - Dataverse Web API v9.2 with OAuth 2.0 client-credentials authentication
 - Supports `@odata.nextLink` pagination for large solutions
 
-[Unreleased]: https://github.com/rededis/dataverse-mcp-server/compare/v0.1.2...HEAD
+[Unreleased]: https://github.com/rededis/dataverse-mcp-server/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/rededis/dataverse-mcp-server/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/rededis/dataverse-mcp-server/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/rededis/dataverse-mcp-server/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/rededis/dataverse-mcp-server/releases/tag/v0.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rededis/dataverse-mcp-server",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rededis/dataverse-mcp-server",
-      "version": "0.1.2",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rededis/dataverse-mcp-server",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "MCP server for Microsoft Dataverse API",
   "main": "dist/index.js",
   "bin": {

--- a/src/tools/schema-tools.ts
+++ b/src/tools/schema-tools.ts
@@ -66,13 +66,52 @@ const AttributeSchema = z.object({
     .describe(
       "Options for Boolean (2 items: false=0, true=1) or Picklist types",
     ),
+  date_format: z
+    .enum(["DateOnly", "DateAndTime"])
+    .optional()
+    .describe(
+      "DateTime only: UI presentation — 'DateOnly' hides the time picker (calendar columns), 'DateAndTime' shows both (default).",
+    ),
+  date_behavior: z
+    .enum(["UserLocal", "DateOnly", "TimeZoneIndependent"])
+    .optional()
+    .describe(
+      "DateTime only: storage/projection semantics. 'UserLocal' (default) shifts by viewer's TZ; 'DateOnly' stores a calendar date (requires date_format=DateOnly); 'TimeZoneIndependent' stores wall-clock time identical across TZs. Per Microsoft docs, changing DateTimeBehavior on an existing column is a one-way operation (UserLocal → other) and cannot be reverted.",
+    ),
 });
 
 type AttributeInput = z.infer<typeof AttributeSchema>;
 
+interface DateTimeFields {
+  type?: string;
+  date_format?: "DateOnly" | "DateAndTime";
+  date_behavior?: "UserLocal" | "DateOnly" | "TimeZoneIndependent";
+}
+
+function validateDateTimeFields(attr: DateTimeFields): void {
+  const usedDateFields =
+    attr.date_format !== undefined || attr.date_behavior !== undefined;
+  if (usedDateFields && attr.type !== "DateTime") {
+    throw new Error(
+      "date_format and date_behavior apply only to DateTime attributes",
+    );
+  }
+  if (
+    attr.date_format === "DateOnly" &&
+    attr.date_behavior !== undefined &&
+    attr.date_behavior !== "DateOnly"
+  ) {
+    throw new Error(
+      `DateOnly format requires DateOnly behavior, got: ${attr.date_behavior}`,
+    );
+  }
+}
+
 export function buildAttributeBody(
   attr: AttributeInput,
 ): Record<string, unknown> {
+  validateDateTimeFields(attr);
+
   const body: Record<string, unknown> = {
     "@odata.type": ATTRIBUTE_ODATA_TYPE_MAP[attr.type],
     LogicalName: attr.logical_name,
@@ -87,6 +126,14 @@ export function buildAttributeBody(
   if (attr.min_value !== undefined) body.MinValue = attr.min_value;
   if (attr.max_value !== undefined) body.MaxValue = attr.max_value;
   if (attr.precision !== undefined) body.Precision = attr.precision;
+
+  if (attr.type === "DateTime") {
+    if (attr.date_format) body.Format = attr.date_format;
+    // DateTimeBehavior is wrapped in { Value: ... } per Dataverse OData spec
+    // (common gotcha — Format is a bare string but Behavior is a typed object)
+    if (attr.date_behavior)
+      body.DateTimeBehavior = { Value: attr.date_behavior };
+  }
 
   if (attr.type === "Boolean") {
     const falseOption = attr.options?.find((o) => o.value === 0) ?? {
@@ -431,6 +478,18 @@ export function registerSchemaTools(
         .number()
         .optional()
         .describe("New precision (Decimal/Money only)"),
+      date_format: z
+        .enum(["DateOnly", "DateAndTime"])
+        .optional()
+        .describe(
+          "DateTime only: change UI presentation. See add_attribute for semantics.",
+        ),
+      date_behavior: z
+        .enum(["UserLocal", "DateOnly", "TimeZoneIndependent"])
+        .optional()
+        .describe(
+          "DateTime only: change storage semantics. ONE-WAY per Microsoft — you can switch from UserLocal to DateOnly or TimeZoneIndependent once, but cannot switch back or between the non-UserLocal values. Dataverse will return 400 if the behavior is already locked.",
+        ),
       language_code: z
         .number()
         .optional()
@@ -443,6 +502,8 @@ export function registerSchemaTools(
         ),
     },
     async (params) => {
+      validateDateTimeFields(params);
+
       const hasMutableField =
         params.display_name !== undefined ||
         params.description !== undefined ||
@@ -450,13 +511,15 @@ export function registerSchemaTools(
         params.max_length !== undefined ||
         params.min_value !== undefined ||
         params.max_value !== undefined ||
-        params.precision !== undefined;
+        params.precision !== undefined ||
+        params.date_format !== undefined ||
+        params.date_behavior !== undefined;
       if (!hasMutableField) {
         return {
           content: [
             {
               type: "text" as const,
-              text: "update_attribute requires at least one of: display_name, description, required, max_length, min_value, max_value, precision. Nothing to update.",
+              text: "update_attribute requires at least one of: display_name, description, required, max_length, min_value, max_value, precision, date_format, date_behavior. Nothing to update.",
             },
           ],
           isError: true,
@@ -502,6 +565,12 @@ export function registerSchemaTools(
       if (params.min_value !== undefined) merged.MinValue = params.min_value;
       if (params.max_value !== undefined) merged.MaxValue = params.max_value;
       if (params.precision !== undefined) merged.Precision = params.precision;
+      if (params.date_format !== undefined) merged.Format = params.date_format;
+      if (params.date_behavior !== undefined) {
+        // DateTimeBehavior wrapped in { Value: ... } on write, matches the
+        // shape GET returns for this property.
+        merged.DateTimeBehavior = { Value: params.date_behavior };
+      }
 
       // Dataverse metadata API does NOT expose ETags (verified empirically
       // with odata.metadata=full — neither ETag response header nor

--- a/tests/schema-tools.test.ts
+++ b/tests/schema-tools.test.ts
@@ -187,6 +187,75 @@ describe("buildAttributeBody", () => {
       }),
     ).toThrow("Picklist attributes require a non-empty 'options' array.");
   });
+
+  describe("DateTime Format/Behavior", () => {
+    it("builds DateOnly/DateOnly date-like column", () => {
+      const body = buildAttributeBody({
+        logical_name: "contoso_effectivedate",
+        type: "DateTime",
+        display_name: "Effective Date",
+        date_format: "DateOnly",
+        date_behavior: "DateOnly",
+      });
+      expect(body.Format).toBe("DateOnly");
+      expect(body.DateTimeBehavior).toEqual({ Value: "DateOnly" });
+    });
+
+    it("builds TimeZoneIndependent datetime without setting Format", () => {
+      const body = buildAttributeBody({
+        logical_name: "contoso_event",
+        type: "DateTime",
+        display_name: "Event",
+        date_behavior: "TimeZoneIndependent",
+      });
+      expect(body.Format).toBeUndefined();
+      expect(body.DateTimeBehavior).toEqual({ Value: "TimeZoneIndependent" });
+    });
+
+    it("omits Format and DateTimeBehavior when not provided (Dataverse defaults apply)", () => {
+      const body = buildAttributeBody({
+        logical_name: "contoso_ts",
+        type: "DateTime",
+        display_name: "Timestamp",
+      });
+      expect(body.Format).toBeUndefined();
+      expect(body.DateTimeBehavior).toBeUndefined();
+    });
+
+    it("rejects DateOnly format with a non-DateOnly behavior", () => {
+      expect(() =>
+        buildAttributeBody({
+          logical_name: "contoso_bad",
+          type: "DateTime",
+          display_name: "Bad",
+          date_format: "DateOnly",
+          date_behavior: "UserLocal",
+        }),
+      ).toThrow(/DateOnly format requires DateOnly behavior, got: UserLocal/);
+    });
+
+    it("rejects date_format on a non-DateTime type", () => {
+      expect(() =>
+        buildAttributeBody({
+          logical_name: "contoso_name",
+          type: "String",
+          display_name: "Name",
+          date_format: "DateOnly",
+        }),
+      ).toThrow(/apply only to DateTime/);
+    });
+
+    it("rejects date_behavior on a non-DateTime type", () => {
+      expect(() =>
+        buildAttributeBody({
+          logical_name: "contoso_count",
+          type: "Integer",
+          display_name: "Count",
+          date_behavior: "UserLocal",
+        }),
+      ).toThrow(/apply only to DateTime/);
+    });
+  });
 });
 
 describe("update_attribute", () => {
@@ -436,6 +505,65 @@ describe("update_attribute", () => {
     expect(opts.body.MinValue).toBe(0);
     expect(opts.body.MaxValue).toBe(9999);
     expect(opts.body.Precision).toBe(4);
+  });
+
+  it("merges date_format and date_behavior into PUT body (DateTime)", async () => {
+    const server = createMockServer();
+    const client = mockClient({
+      ...existingAttribute,
+      LogicalName: "fundai_effectivedate",
+      SchemaName: "Fundai_effectivedate",
+      "@odata.type": "#Microsoft.Dynamics.CRM.DateTimeAttributeMetadata",
+      Format: "DateAndTime",
+      DateTimeBehavior: { Value: "UserLocal" },
+    } as any);
+    registerSchemaTools(server as any, client);
+
+    await server.tools.get("update_attribute")!.handler({
+      entity_logical_name: "fundai_x",
+      attribute_logical_name: "fundai_effectivedate",
+      type: "DateTime",
+      date_format: "DateOnly",
+      date_behavior: "DateOnly",
+    });
+
+    const [, opts] = client.request.mock.calls[0];
+    expect(opts.body.Format).toBe("DateOnly");
+    expect(opts.body.DateTimeBehavior).toEqual({ Value: "DateOnly" });
+  });
+
+  it("rejects date_format on non-DateTime type without calling HTTP", async () => {
+    const server = createMockServer();
+    const client = mockClient();
+    registerSchemaTools(server as any, client);
+
+    await expect(
+      server.tools.get("update_attribute")!.handler({
+        entity_logical_name: "fundai_x",
+        attribute_logical_name: "fundai_col",
+        type: "String",
+        date_format: "DateOnly",
+      }),
+    ).rejects.toThrow(/apply only to DateTime/);
+    expect(client.get).not.toHaveBeenCalled();
+    expect(client.request).not.toHaveBeenCalled();
+  });
+
+  it("rejects DateOnly format with mismatched behavior on update_attribute", async () => {
+    const server = createMockServer();
+    const client = mockClient();
+    registerSchemaTools(server as any, client);
+
+    await expect(
+      server.tools.get("update_attribute")!.handler({
+        entity_logical_name: "fundai_x",
+        attribute_logical_name: "fundai_col",
+        type: "DateTime",
+        date_format: "DateOnly",
+        date_behavior: "UserLocal",
+      }),
+    ).rejects.toThrow(/DateOnly format requires DateOnly behavior/);
+    expect(client.get).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
Closes #24.

## Summary
Expose Dataverse \`DateTimeAttributeMetadata\`'s two knobs through MCP so calendar-only columns and TZ-independent timestamps are buildable without Power Apps maker UI round-trip:
- \`date_format\`: \`"DateOnly" | "DateAndTime"\` — maps to \`Format\` in OData body
- \`date_behavior\`: \`"UserLocal" | "DateOnly" | "TimeZoneIndependent"\` — maps to \`DateTimeBehavior: { Value: ... }\` (wrapped form is a Dataverse gotcha)

Available on both \`add_attribute\` and \`update_attribute\`.

## Validation (before any HTTP call)
- \`date_format=DateOnly\` requires \`date_behavior=DateOnly\` — mismatches rejected with \`DateOnly format requires DateOnly behavior, got: <value>\`
- \`date_format\` / \`date_behavior\` on a non-DateTime type rejected with \`apply only to DateTime\`
- Both checks run through a shared \`validateDateTimeFields\` helper used by \`buildAttributeBody\` (create/add path) and the \`update_attribute\` handler

## One-way Behavior mutation
Per Microsoft docs, \`DateTimeBehavior\` can be changed once (UserLocal → DateOnly or UserLocal → TimeZoneIndependent) and cannot be reverted. Not enforced client-side — Dataverse returns 400 for locked columns and that's passed through. The \`update_attribute\` tool description surfaces this so the model warns users before calling on a locked column.

## Version — 0.2.0, not 0.1.3
\`AttributeSchema\` gained two public fields → new MCP-visible schema surface → strict semver reads this as a minor addition. Backward compatible: existing calls without the new fields behave identically to 0.1.x.

## Test plan
- [x] \`npm run lint\` / \`npm run build\` clean
- [x] 91 unit tests pass (+9 new): DateOnly/DateOnly happy path, TimeZoneIndependent path, defaults unchanged, mismatch rejected, non-DateTime type rejected (both for add and update), update_attribute merges Format + DateTimeBehavior into PUT body correctly
- [ ] **Live test after restart** (requires user to restart Claude Code so the local \`dist/\` with new tool schemas is picked up by MCP):
  - \`add_attribute\` fundai_achtransaction.fundai_effectivedate with DateOnly/DateOnly
  - \`get_entity_schema\` to verify Format=DateOnly, DateTimeBehavior.Value=DateOnly
  - \`add_attribute\` with TimeZoneIndependent
  - Invalid combo DateOnly+UserLocal → expect error from the tool
  - \`update_attribute\` changing \`date_format\`
  - \`delete_attribute\` cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)