### PR TITLE
Release 0.3.0: get_attribute_dependencies tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- New tool `get_attribute_dependencies_list_url` (closes #27): returns a Power Apps maker UI URL for an attribute. Use after `delete_attribute` fails with error 0x8004f01f, or proactively before any destructive change. The URL points to the field details page in Power Apps maker; from there a single "Show dependencies" click yields the rich dependency graph (forms, views, workflows, business rules, calculated columns, …) with in-place edit links per dependency.
-
-### Notes on the URL-only approach
-
-A full programmatic dependency-listing tool (parsing `RetrieveDependenciesForDelete`, mapping component-type integers, resolving names per type) would be ~150 lines and require a hand-maintained component-type enum. The link-only design solves the practical problem with ~30 lines: every workflow path that needed deps ended in "go to maker UI to edit them" anyway, so the JSON intermediate offered little real value. If a programmatic listing turns out useful for automation later, it can be a follow-up additive tool.
+- New tool `get_attribute_dependencies` (closes #27): list CRM components (forms, views, workflows, business rules, plugins, …) that reference a given attribute. Use after `delete_attribute` fails with error 0x8004f01f, or proactively before any destructive change. Returns a flat array of `{ component_type, component_type_name, object_id, name }`.
 
 ### Implementation
 
-- The OrganizationId required for the maker URL is fetched from `/WhoAmI` once per process and cached at module scope.
-- Entity and attribute MetadataIds are fetched in parallel with the cached OrganizationId via `Promise.all`.
+- Backed by the Dataverse `RetrieveDependenciesForDelete` function with `ComponentType=2` (Attribute).
+- Hand-curated `componenttype` int → friendly name table covers the 30+ types most likely to surface for attributes; unknown ints fall back to `ComponentType_<N>` so callers still see the raw value.
+- Best-effort name resolution: dependencies are grouped by component type and resolved in parallel batches against their respective entity sets (`systemforms`, `savedqueries`, `workflows`, `reports`, `webresourceset`, `fieldsecurityprofiles`, `appmodules`, `sdkmessageprocessingsteps`). One HTTP call per dependent type, not per dependency. Component types without a resolver (e.g. AppModule sub-types, niche types) keep `name: null`.
+
+### Design note
+
+An earlier iteration of this PR returned a Power Apps maker UI deep-link instead of a structured listing. That approach turned out unworkable: the URL pattern requires the Power Platform **EnvironmentId**, which is distinct from the Dataverse **OrganizationId** returned by `/WhoAmI`, and getting EnvironmentId requires a separate Power Platform Admin API with different OAuth scopes. Pivoted to the structured listing approach which is fully self-contained within the existing Dataverse Web API auth.
 
 ## [0.2.0] - 2026-04-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-04-25
+
+### Added
+
+- New tool `get_attribute_dependencies_list_url` (closes #27): returns a Power Apps maker UI URL for an attribute. Use after `delete_attribute` fails with error 0x8004f01f, or proactively before any destructive change. The URL points to the field details page in Power Apps maker; from there a single "Show dependencies" click yields the rich dependency graph (forms, views, workflows, business rules, calculated columns, …) with in-place edit links per dependency.
+
+### Notes on the URL-only approach
+
+A full programmatic dependency-listing tool (parsing `RetrieveDependenciesForDelete`, mapping component-type integers, resolving names per type) would be ~150 lines and require a hand-maintained component-type enum. The link-only design solves the practical problem with ~30 lines: every workflow path that needed deps ended in "go to maker UI to edit them" anyway, so the JSON intermediate offered little real value. If a programmatic listing turns out useful for automation later, it can be a follow-up additive tool.
+
+### Implementation
+
+- The OrganizationId required for the maker URL is fetched from `/WhoAmI` once per process and cached at module scope.
+- Entity and attribute MetadataIds are fetched in parallel with the cached OrganizationId via `Promise.all`.
+
 ## [0.2.0] - 2026-04-24
 
 ### Added
@@ -87,7 +102,8 @@ All picklist tools accept either `entity_logical_name` + `attribute_logical_name
 - Dataverse Web API v9.2 with OAuth 2.0 client-credentials authentication
 - Supports `@odata.nextLink` pagination for large solutions
 
-[Unreleased]: https://github.com/rededis/dataverse-mcp-server/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/rededis/dataverse-mcp-server/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/rededis/dataverse-mcp-server/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/rededis/dataverse-mcp-server/compare/v0.1.2...v0.2.0
 [0.1.2]: https://github.com/rededis/dataverse-mcp-server/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/rededis/dataverse-mcp-server/compare/v0.1.0...v0.1.1

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ MCP (Model Context Protocol) server for Microsoft Dataverse API with [safe-by-de
 | `add_attribute` | Add a column to an existing table |
 | `update_attribute` | Update column metadata (display name, required level, bounds, …) |
 | `delete_attribute` | Delete a column (disabled by default, see [Safety](#safety)) |
+| `get_attribute_dependencies_list_url` | Returns a Power Apps maker URL for the column; click "Show dependencies" there to inspect what references it (use after `delete_attribute` fails with 0x8004f01f) |
 | `create_relationship` | Create relationships between tables (1:N, N:N) |
 
 > Dataverse does **not** allow changing a column's logical name or type. To "rename" or change type: create a new column, migrate data via `update_record`, then `delete_attribute` on the old one.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ MCP (Model Context Protocol) server for Microsoft Dataverse API with [safe-by-de
 | `add_attribute` | Add a column to an existing table |
 | `update_attribute` | Update column metadata (display name, required level, bounds, …) |
 | `delete_attribute` | Delete a column (disabled by default, see [Safety](#safety)) |
-| `get_attribute_dependencies_list_url` | Returns a Power Apps maker URL for the column; click "Show dependencies" there to inspect what references it (use after `delete_attribute` fails with 0x8004f01f) |
+| `get_attribute_dependencies` | List CRM components (forms, views, workflows, …) that reference a column — use after `delete_attribute` fails with 0x8004f01f |
 | `create_relationship` | Create relationships between tables (1:N, N:N) |
 
 > Dataverse does **not** allow changing a column's logical name or type. To "rename" or change type: create a new column, migrate data via `update_record`, then `delete_attribute` on the old one.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rededis/dataverse-mcp-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rededis/dataverse-mcp-server",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rededis/dataverse-mcp-server",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "MCP server for Microsoft Dataverse API",
   "main": "dist/index.js",
   "bin": {

--- a/src/tools/schema-tools.ts
+++ b/src/tools/schema-tools.ts
@@ -1,7 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import type { DataverseClient } from "../client.js";
-import { escapeODataString } from "./data-tools.js";
+import { buildODataQuery, escapeODataString } from "./data-tools.js";
 
 const ATTRIBUTE_ODATA_TYPE_MAP: Record<string, string> = {
   String: "Microsoft.Dynamics.CRM.StringAttributeMetadata",
@@ -176,26 +176,115 @@ export function buildAttributeBody(
   return body;
 }
 
-// Cached at module scope: OrganizationId never changes for a given Dataverse
-// connection. First call to get_attribute_dependencies_list_url pays the
-// WhoAmI HTTP cost; subsequent calls reuse the value.
-let cachedOrganizationId: string | null = null;
+// Common componenttype int → friendly name. Hand-curated from Microsoft docs:
+// https://learn.microsoft.com/en-us/power-apps/developer/data-platform/webapi/reference/dependency
+// Covers the types most likely to appear as attribute dependencies; unknown
+// values fall back to "ComponentType_<N>" so the caller still sees the raw int.
+const COMPONENT_TYPE_NAMES: Record<number, string> = {
+  1: "Entity",
+  2: "Attribute",
+  3: "Relationship",
+  9: "OptionSet",
+  10: "EntityRelationship",
+  14: "EntityKey",
+  20: "Role",
+  22: "DisplayString",
+  24: "Form",
+  25: "Organization",
+  26: "SavedQuery",
+  27: "Workflow",
+  29: "Report",
+  31: "ReportCategory",
+  32: "ReportEntity",
+  46: "DuplicateRule",
+  59: "SavedQueryVisualization",
+  60: "SystemForm",
+  61: "WebResource",
+  62: "SiteMap",
+  65: "HierarchyRule",
+  66: "CustomControl",
+  70: "FieldSecurityProfile",
+  71: "FieldPermission",
+  80: "AppModule",
+  90: "PluginAssembly",
+  91: "PluginType",
+  92: "SDKMessageProcessingStep",
+  93: "SDKMessageProcessingStepImage",
+  102: "Workflow",
+  103: "ConvertRule",
+  150: "Theme",
+  152: "ConnectionRole",
+  166: "SLA",
+};
 
-async function getOrganizationId(client: DataverseClient): Promise<string> {
-  if (cachedOrganizationId) return cachedOrganizationId;
-  const result = (await client.get("/WhoAmI")) as { OrganizationId?: string };
-  if (!result.OrganizationId) {
-    throw new Error(
-      "Failed to resolve OrganizationId from WhoAmI response — required to build the Power Apps maker URL.",
-    );
-  }
-  cachedOrganizationId = result.OrganizationId;
-  return cachedOrganizationId;
+// Per-componenttype info to do best-effort name resolution from the dep's
+// objectid back to a human-readable name. Component types not listed here
+// keep `name: null` in the output (caller still gets the raw object_id).
+interface DependencyResolver {
+  entitySet: string;
+  idField: string;
+  nameField: string;
 }
 
-// Exposed for tests to reset between cases.
-export function _resetOrganizationIdCache(): void {
-  cachedOrganizationId = null;
+const DEPENDENCY_RESOLVERS: Record<number, DependencyResolver> = {
+  26: { entitySet: "savedqueries", idField: "savedqueryid", nameField: "name" },
+  27: { entitySet: "workflows", idField: "workflowid", nameField: "name" },
+  29: { entitySet: "reports", idField: "reportid", nameField: "name" },
+  60: { entitySet: "systemforms", idField: "formid", nameField: "name" },
+  61: {
+    entitySet: "webresourceset",
+    idField: "webresourceid",
+    nameField: "name",
+  },
+  70: {
+    entitySet: "fieldsecurityprofiles",
+    idField: "fieldsecurityprofileid",
+    nameField: "name",
+  },
+  80: { entitySet: "appmodules", idField: "appmoduleid", nameField: "name" },
+  92: {
+    entitySet: "sdkmessageprocessingsteps",
+    idField: "sdkmessageprocessingstepid",
+    nameField: "name",
+  },
+  102: { entitySet: "workflows", idField: "workflowid", nameField: "name" },
+};
+
+interface RawDependency {
+  dependentcomponenttype: number;
+  dependentcomponentobjectid: string;
+}
+
+interface FlatDependency {
+  component_type: number;
+  component_type_name: string;
+  object_id: string;
+  name: string | null;
+}
+
+async function resolveDependencyNames(
+  client: DataverseClient,
+  componentType: number,
+  ids: string[],
+): Promise<Map<string, string>> {
+  const resolver = DEPENDENCY_RESOLVERS[componentType];
+  if (!resolver) return new Map();
+
+  const filter = ids.map((id) => `${resolver.idField} eq ${id}`).join(" or ");
+  const query = buildODataQuery({
+    $filter: filter,
+    $select: `${resolver.idField},${resolver.nameField}`,
+  });
+  const result = (await client.get(`/${resolver.entitySet}${query}`)) as {
+    value: Array<Record<string, string>>;
+  };
+  const map = new Map<string, string>();
+  for (const row of result.value) {
+    const id = row[resolver.idField];
+    const name = row[resolver.nameField];
+    if (id && name) map.set(id, name);
+  }
+  return map;
 }
 
 export function registerSchemaTools(
@@ -672,8 +761,8 @@ export function registerSchemaTools(
   }
 
   server.tool(
-    "get_attribute_dependencies_list_url",
-    "Returns a Power Apps maker UI URL for an attribute. Open the URL in a browser to see the column's details and click 'Show dependencies' to inspect what references it (forms, views, workflows, business rules, calculated columns, etc.). Use this when delete_attribute fails with error 0x8004f01f, or proactively before any destructive change. The URL points to the field details page; from there the maker UI handles the full dependency graph and offers in-place edit links per dependency.",
+    "get_attribute_dependencies",
+    "List CRM components (forms, views, workflows, business rules, calculated columns, plugins, …) that reference a given attribute. Use this when delete_attribute fails with error 0x8004f01f, or proactively before any destructive change. Returns a flat array of { component_type, component_type_name, object_id, name }; name is best-effort (resolved for common types — SystemForm, SavedQuery, Workflow, Report, WebResource, FieldSecurityProfile, AppModule, SDKMessageProcessingStep — null otherwise). Backed by the Dataverse RetrieveDependenciesForDelete function.",
     {
       entity_logical_name: z.string().describe("Logical name of the entity"),
       attribute_logical_name: z.string().describe("Logical name of the column"),
@@ -681,45 +770,59 @@ export function registerSchemaTools(
     async ({ entity_logical_name, attribute_logical_name }) => {
       const entityEscaped = escapeODataString(entity_logical_name);
       const attrEscaped = escapeODataString(attribute_logical_name);
-      const entityPath = `/EntityDefinitions(LogicalName='${entityEscaped}')`;
-      const attrPath = `${entityPath}/Attributes(LogicalName='${attrEscaped}')`;
+      const attrPath = `/EntityDefinitions(LogicalName='${entityEscaped}')/Attributes(LogicalName='${attrEscaped}')`;
 
-      // Fire OrganizationId, Entity MetadataId, and Attribute MetadataId in
-      // parallel — none depend on each other. WhoAmI is short-circuited via
-      // the module-scope cache after the first call.
-      const [orgId, entityResult, attrResult] = await Promise.all([
-        getOrganizationId(client),
-        client.get(`${entityPath}?$select=MetadataId`) as Promise<{
-          MetadataId?: string;
-        }>,
-        client.get(`${attrPath}?$select=MetadataId`) as Promise<{
-          MetadataId?: string;
-        }>,
-      ]);
-
-      const entityMetadataId = entityResult.MetadataId;
-      const attrMetadataId = attrResult.MetadataId;
-      if (!entityMetadataId) {
-        throw new Error(`Entity not found: ${entity_logical_name}`);
-      }
-      if (!attrMetadataId) {
+      // Step 1: resolve attribute MetadataId (RetrieveDependenciesForDelete
+      // takes the raw GUID, not a logical-name lookup).
+      const attrResult = (await client.get(
+        `${attrPath}?$select=MetadataId`,
+      )) as { MetadataId?: string };
+      if (!attrResult.MetadataId) {
         throw new Error(
           `Attribute not found: ${entity_logical_name}.${attribute_logical_name}`,
         );
       }
 
-      const url = `https://make.powerapps.com/environments/${orgId}/entities/${entityMetadataId}/fields/${attrMetadataId}`;
+      // Step 2: ask Dataverse for the dependency list. ComponentType=2 means
+      // the target is an Attribute. Returns a {value:[Dependency]} collection;
+      // each Dependency has dependentcomponenttype + dependentcomponentobjectid.
+      const depsResult = (await client.get(
+        `/RetrieveDependenciesForDelete(ComponentType=2,ObjectId=${attrResult.MetadataId})`,
+      )) as { value: RawDependency[] };
 
-      const payload = {
-        url,
-        hint: "Open the URL, then click 'Show dependencies' on the field details page to see what references this column.",
-        organization_id: orgId,
-        entity_metadata_id: entityMetadataId,
-        attribute_metadata_id: attrMetadataId,
-      };
+      // Step 3: group dep ids by componenttype, then resolve names per group
+      // in parallel. Each group is one HTTP call instead of N.
+      const idsByType = new Map<number, string[]>();
+      for (const dep of depsResult.value) {
+        const list = idsByType.get(dep.dependentcomponenttype) ?? [];
+        list.push(dep.dependentcomponentobjectid);
+        idsByType.set(dep.dependentcomponenttype, list);
+      }
+      const namesByType = new Map<number, Map<string, string>>();
+      await Promise.all(
+        Array.from(idsByType.entries()).map(async ([type, ids]) => {
+          namesByType.set(
+            type,
+            await resolveDependencyNames(client, type, ids),
+          );
+        }),
+      );
+
+      const flat: FlatDependency[] = depsResult.value.map((dep) => ({
+        component_type: dep.dependentcomponenttype,
+        component_type_name:
+          COMPONENT_TYPE_NAMES[dep.dependentcomponenttype] ??
+          `ComponentType_${dep.dependentcomponenttype}`,
+        object_id: dep.dependentcomponentobjectid,
+        name:
+          namesByType
+            .get(dep.dependentcomponenttype)
+            ?.get(dep.dependentcomponentobjectid) ?? null,
+      }));
+
       return {
         content: [
-          { type: "text" as const, text: JSON.stringify(payload, null, 2) },
+          { type: "text" as const, text: JSON.stringify(flat, null, 2) },
         ],
       };
     },

--- a/src/tools/schema-tools.ts
+++ b/src/tools/schema-tools.ts
@@ -176,6 +176,28 @@ export function buildAttributeBody(
   return body;
 }
 
+// Cached at module scope: OrganizationId never changes for a given Dataverse
+// connection. First call to get_attribute_dependencies_list_url pays the
+// WhoAmI HTTP cost; subsequent calls reuse the value.
+let cachedOrganizationId: string | null = null;
+
+async function getOrganizationId(client: DataverseClient): Promise<string> {
+  if (cachedOrganizationId) return cachedOrganizationId;
+  const result = (await client.get("/WhoAmI")) as { OrganizationId?: string };
+  if (!result.OrganizationId) {
+    throw new Error(
+      "Failed to resolve OrganizationId from WhoAmI response — required to build the Power Apps maker URL.",
+    );
+  }
+  cachedOrganizationId = result.OrganizationId;
+  return cachedOrganizationId;
+}
+
+// Exposed for tests to reset between cases.
+export function _resetOrganizationIdCache(): void {
+  cachedOrganizationId = null;
+}
+
 export function registerSchemaTools(
   server: McpServer,
   client: DataverseClient,
@@ -648,4 +670,58 @@ export function registerSchemaTools(
       }),
     );
   }
+
+  server.tool(
+    "get_attribute_dependencies_list_url",
+    "Returns a Power Apps maker UI URL for an attribute. Open the URL in a browser to see the column's details and click 'Show dependencies' to inspect what references it (forms, views, workflows, business rules, calculated columns, etc.). Use this when delete_attribute fails with error 0x8004f01f, or proactively before any destructive change. The URL points to the field details page; from there the maker UI handles the full dependency graph and offers in-place edit links per dependency.",
+    {
+      entity_logical_name: z.string().describe("Logical name of the entity"),
+      attribute_logical_name: z.string().describe("Logical name of the column"),
+    },
+    async ({ entity_logical_name, attribute_logical_name }) => {
+      const entityEscaped = escapeODataString(entity_logical_name);
+      const attrEscaped = escapeODataString(attribute_logical_name);
+      const entityPath = `/EntityDefinitions(LogicalName='${entityEscaped}')`;
+      const attrPath = `${entityPath}/Attributes(LogicalName='${attrEscaped}')`;
+
+      // Fire OrganizationId, Entity MetadataId, and Attribute MetadataId in
+      // parallel — none depend on each other. WhoAmI is short-circuited via
+      // the module-scope cache after the first call.
+      const [orgId, entityResult, attrResult] = await Promise.all([
+        getOrganizationId(client),
+        client.get(`${entityPath}?$select=MetadataId`) as Promise<{
+          MetadataId?: string;
+        }>,
+        client.get(`${attrPath}?$select=MetadataId`) as Promise<{
+          MetadataId?: string;
+        }>,
+      ]);
+
+      const entityMetadataId = entityResult.MetadataId;
+      const attrMetadataId = attrResult.MetadataId;
+      if (!entityMetadataId) {
+        throw new Error(`Entity not found: ${entity_logical_name}`);
+      }
+      if (!attrMetadataId) {
+        throw new Error(
+          `Attribute not found: ${entity_logical_name}.${attribute_logical_name}`,
+        );
+      }
+
+      const url = `https://make.powerapps.com/environments/${orgId}/entities/${entityMetadataId}/fields/${attrMetadataId}`;
+
+      const payload = {
+        url,
+        hint: "Open the URL, then click 'Show dependencies' on the field details page to see what references this column.",
+        organization_id: orgId,
+        entity_metadata_id: entityMetadataId,
+        attribute_metadata_id: attrMetadataId,
+      };
+      return {
+        content: [
+          { type: "text" as const, text: JSON.stringify(payload, null, 2) },
+        ],
+      };
+    },
+  );
 }

--- a/tests/schema-tools.test.ts
+++ b/tests/schema-tools.test.ts
@@ -1,6 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
-  _resetOrganizationIdCache,
   buildAttributeBody,
   registerSchemaTools,
 } from "../src/tools/schema-tools.js";
@@ -620,125 +619,223 @@ describe("delete_attribute", () => {
   });
 });
 
-describe("get_attribute_dependencies_list_url", () => {
-  const ORG_ID = "5c8ce4d5-a81e-e726-82d5-26ece5066319";
-  const ENTITY_META = "08bb20a4-9d75-f011-b4cb-7ced8d703de4";
+describe("get_attribute_dependencies", () => {
   const ATTR_META = "be1ee949-dc3f-f111-88b4-6045bd070a95";
+  const FORM_A = "11111111-1111-1111-1111-111111111111";
+  const FORM_B = "22222222-2222-2222-2222-222222222222";
+  const VIEW_A = "33333333-3333-3333-3333-333333333333";
+  const UNKNOWN_OBJ = "44444444-4444-4444-4444-444444444444";
 
-  beforeEach(() => {
-    _resetOrganizationIdCache();
-  });
-
-  function makeClient({
-    whoami = { OrganizationId: ORG_ID },
-    entity = { MetadataId: ENTITY_META },
-    attr = { MetadataId: ATTR_META },
-  }: {
-    whoami?: unknown;
-    entity?: unknown;
-    attr?: unknown;
-  } = {}) {
+  function makeClient(
+    overrides: {
+      attrResponse?: Record<string, unknown>;
+      deps?: Array<{
+        dependentcomponenttype: number;
+        dependentcomponentobjectid: string;
+      }>;
+      formNames?: Map<string, string>;
+      viewNames?: Map<string, string>;
+    } = {},
+  ) {
+    const {
+      attrResponse = { MetadataId: ATTR_META },
+      deps = [
+        { dependentcomponenttype: 60, dependentcomponentobjectid: FORM_A },
+        { dependentcomponenttype: 60, dependentcomponentobjectid: FORM_B },
+        { dependentcomponenttype: 26, dependentcomponentobjectid: VIEW_A },
+      ],
+      formNames = new Map([
+        [FORM_A, "Information"],
+        [FORM_B, "Quick Create"],
+      ]),
+      viewNames = new Map([[VIEW_A, "Active ACH Transactions"]]),
+    } = overrides;
     return {
       get: vi.fn().mockImplementation((path: string) => {
-        if (path === "/WhoAmI") return Promise.resolve(whoami);
-        if (path.includes("/Attributes(")) return Promise.resolve(attr);
-        if (path.includes("/EntityDefinitions(")) return Promise.resolve(entity);
+        if (path.includes("/EntityDefinitions(") && path.includes("/Attributes(")) {
+          return Promise.resolve(attrResponse);
+        }
+        if (path.startsWith("/RetrieveDependenciesForDelete")) {
+          return Promise.resolve({ value: deps });
+        }
+        if (path.startsWith("/systemforms")) {
+          const value = Array.from(formNames.entries()).map(([id, name]) => ({
+            formid: id,
+            name,
+          }));
+          return Promise.resolve({ value });
+        }
+        if (path.startsWith("/savedqueries")) {
+          const value = Array.from(viewNames.entries()).map(([id, name]) => ({
+            savedqueryid: id,
+            name,
+          }));
+          return Promise.resolve({ value });
+        }
         throw new Error(`unexpected GET ${path}`);
       }),
     } as any;
   }
 
-  it("returns the maker URL with the right GUIDs and metadata in the payload", async () => {
+  it("returns a flat array with resolved names, mapped component-type names, and the right RetrieveDependenciesForDelete call", async () => {
     const server = createMockServer();
     const client = makeClient();
     registerSchemaTools(server as any, client);
 
     const result = await server.tools
-      .get("get_attribute_dependencies_list_url")!
+      .get("get_attribute_dependencies")!
       .handler({
         entity_logical_name: "fundai_achtransaction",
         attribute_logical_name: "fundai_settledat",
       });
 
-    const payload = JSON.parse(result.content[0].text);
-    expect(payload.url).toBe(
-      `https://make.powerapps.com/environments/${ORG_ID}/entities/${ENTITY_META}/fields/${ATTR_META}`,
+    const paths = client.get.mock.calls.map(([p]: [string]) => p);
+    expect(paths).toContain(
+      `/RetrieveDependenciesForDelete(ComponentType=2,ObjectId=${ATTR_META})`,
     );
-    expect(payload.organization_id).toBe(ORG_ID);
-    expect(payload.entity_metadata_id).toBe(ENTITY_META);
-    expect(payload.attribute_metadata_id).toBe(ATTR_META);
-    expect(payload.hint).toMatch(/Show dependencies/);
+
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload).toEqual([
+      {
+        component_type: 60,
+        component_type_name: "SystemForm",
+        object_id: FORM_A,
+        name: "Information",
+      },
+      {
+        component_type: 60,
+        component_type_name: "SystemForm",
+        object_id: FORM_B,
+        name: "Quick Create",
+      },
+      {
+        component_type: 26,
+        component_type_name: "SavedQuery",
+        object_id: VIEW_A,
+        name: "Active ACH Transactions",
+      },
+    ]);
   });
 
-  it("caches OrganizationId across multiple invocations (only one /WhoAmI call total)", async () => {
+  it("batches name resolution per component type (one HTTP call per type, not per dep)", async () => {
     const server = createMockServer();
     const client = makeClient();
     registerSchemaTools(server as any, client);
 
-    const tool = server.tools.get("get_attribute_dependencies_list_url")!;
-    await tool.handler({
+    await server.tools.get("get_attribute_dependencies")!.handler({
       entity_logical_name: "e",
       attribute_logical_name: "a",
     });
-    await tool.handler({
-      entity_logical_name: "e2",
-      attribute_logical_name: "a2",
-    });
-    await tool.handler({
-      entity_logical_name: "e3",
-      attribute_logical_name: "a3",
-    });
-
-    const whoamiCalls = client.get.mock.calls.filter(
-      ([p]: [string]) => p === "/WhoAmI",
-    );
-    expect(whoamiCalls).toHaveLength(1);
-  });
-
-  it("escapes single quotes in logical names (OData injection)", async () => {
-    const server = createMockServer();
-    const client = makeClient();
-    registerSchemaTools(server as any, client);
-
-    await server.tools
-      .get("get_attribute_dependencies_list_url")!
-      .handler({
-        entity_logical_name: "weird'entity",
-        attribute_logical_name: "odd'col",
-      });
 
     const paths = client.get.mock.calls.map(([p]: [string]) => p);
-    expect(paths).toContain(
-      "/EntityDefinitions(LogicalName='weird''entity')?$select=MetadataId",
-    );
-    expect(paths).toContain(
-      "/EntityDefinitions(LogicalName='weird''entity')/Attributes(LogicalName='odd''col')?$select=MetadataId",
-    );
+    const formCalls = paths.filter((p: string) => p.startsWith("/systemforms"));
+    const viewCalls = paths.filter((p: string) => p.startsWith("/savedqueries"));
+    // 2 forms in one batch, 1 view in one batch — 2 HTTP calls total, not 3.
+    expect(formCalls).toHaveLength(1);
+    expect(viewCalls).toHaveLength(1);
+  });
+
+  it("falls back to ComponentType_<N> and null name for unknown component types", async () => {
+    const server = createMockServer();
+    const client = makeClient({
+      deps: [
+        {
+          dependentcomponenttype: 9999,
+          dependentcomponentobjectid: UNKNOWN_OBJ,
+        },
+      ],
+    });
+    registerSchemaTools(server as any, client);
+
+    const result = await server.tools
+      .get("get_attribute_dependencies")!
+      .handler({
+        entity_logical_name: "e",
+        attribute_logical_name: "a",
+      });
+
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload).toEqual([
+      {
+        component_type: 9999,
+        component_type_name: "ComponentType_9999",
+        object_id: UNKNOWN_OBJ,
+        name: null,
+      },
+    ]);
+  });
+
+  it("returns empty array when the attribute has no dependencies", async () => {
+    const server = createMockServer();
+    const client = makeClient({ deps: [] });
+    registerSchemaTools(server as any, client);
+
+    const result = await server.tools
+      .get("get_attribute_dependencies")!
+      .handler({
+        entity_logical_name: "e",
+        attribute_logical_name: "a",
+      });
+
+    expect(JSON.parse(result.content[0].text)).toEqual([]);
   });
 
   it("throws if the attribute lookup returns no MetadataId", async () => {
     const server = createMockServer();
-    const client = makeClient({ attr: {} });
+    const client = makeClient({ attrResponse: {} });
     registerSchemaTools(server as any, client);
 
     await expect(
-      server.tools.get("get_attribute_dependencies_list_url")!.handler({
+      server.tools.get("get_attribute_dependencies")!.handler({
         entity_logical_name: "fundai_x",
         attribute_logical_name: "missing_attr",
       }),
     ).rejects.toThrow(/Attribute not found: fundai_x\.missing_attr/);
   });
 
-  it("throws if WhoAmI omits OrganizationId", async () => {
+  it("escapes single quotes in logical names (OData injection)", async () => {
     const server = createMockServer();
-    const client = makeClient({ whoami: {} });
+    const client = makeClient({ deps: [] });
     registerSchemaTools(server as any, client);
 
-    await expect(
-      server.tools.get("get_attribute_dependencies_list_url")!.handler({
+    await server.tools.get("get_attribute_dependencies")!.handler({
+      entity_logical_name: "weird'entity",
+      attribute_logical_name: "odd'col",
+    });
+
+    const paths = client.get.mock.calls.map(([p]: [string]) => p);
+    expect(paths).toContain(
+      "/EntityDefinitions(LogicalName='weird''entity')/Attributes(LogicalName='odd''col')?$select=MetadataId",
+    );
+  });
+
+  it("preserves dep order from RetrieveDependenciesForDelete and resolves names per ID, even with duplicates across types", async () => {
+    const server = createMockServer();
+    const client = makeClient({
+      deps: [
+        { dependentcomponenttype: 26, dependentcomponentobjectid: VIEW_A },
+        { dependentcomponenttype: 60, dependentcomponentobjectid: FORM_A },
+        { dependentcomponenttype: 60, dependentcomponentobjectid: FORM_B },
+      ],
+    });
+    registerSchemaTools(server as any, client);
+
+    const result = await server.tools
+      .get("get_attribute_dependencies")!
+      .handler({
         entity_logical_name: "e",
         attribute_logical_name: "a",
-      }),
-    ).rejects.toThrow(/OrganizationId/);
+      });
+
+    const payload = JSON.parse(result.content[0].text);
+    // Output preserves the original dep order, even though resolution was batched per type.
+    expect(payload.map((d: { component_type: number }) => d.component_type)).toEqual([
+      26, 60, 60,
+    ]);
+    expect(payload.map((d: { name: string | null }) => d.name)).toEqual([
+      "Active ACH Transactions",
+      "Information",
+      "Quick Create",
+    ]);
   });
 });

--- a/tests/schema-tools.test.ts
+++ b/tests/schema-tools.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  _resetOrganizationIdCache,
   buildAttributeBody,
   registerSchemaTools,
 } from "../src/tools/schema-tools.js";
@@ -616,5 +617,128 @@ describe("delete_attribute", () => {
     expect(client.delete).toHaveBeenCalledWith(
       "/EntityDefinitions(LogicalName='weird''name')/Attributes(LogicalName='odd''col')",
     );
+  });
+});
+
+describe("get_attribute_dependencies_list_url", () => {
+  const ORG_ID = "5c8ce4d5-a81e-e726-82d5-26ece5066319";
+  const ENTITY_META = "08bb20a4-9d75-f011-b4cb-7ced8d703de4";
+  const ATTR_META = "be1ee949-dc3f-f111-88b4-6045bd070a95";
+
+  beforeEach(() => {
+    _resetOrganizationIdCache();
+  });
+
+  function makeClient({
+    whoami = { OrganizationId: ORG_ID },
+    entity = { MetadataId: ENTITY_META },
+    attr = { MetadataId: ATTR_META },
+  }: {
+    whoami?: unknown;
+    entity?: unknown;
+    attr?: unknown;
+  } = {}) {
+    return {
+      get: vi.fn().mockImplementation((path: string) => {
+        if (path === "/WhoAmI") return Promise.resolve(whoami);
+        if (path.includes("/Attributes(")) return Promise.resolve(attr);
+        if (path.includes("/EntityDefinitions(")) return Promise.resolve(entity);
+        throw new Error(`unexpected GET ${path}`);
+      }),
+    } as any;
+  }
+
+  it("returns the maker URL with the right GUIDs and metadata in the payload", async () => {
+    const server = createMockServer();
+    const client = makeClient();
+    registerSchemaTools(server as any, client);
+
+    const result = await server.tools
+      .get("get_attribute_dependencies_list_url")!
+      .handler({
+        entity_logical_name: "fundai_achtransaction",
+        attribute_logical_name: "fundai_settledat",
+      });
+
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.url).toBe(
+      `https://make.powerapps.com/environments/${ORG_ID}/entities/${ENTITY_META}/fields/${ATTR_META}`,
+    );
+    expect(payload.organization_id).toBe(ORG_ID);
+    expect(payload.entity_metadata_id).toBe(ENTITY_META);
+    expect(payload.attribute_metadata_id).toBe(ATTR_META);
+    expect(payload.hint).toMatch(/Show dependencies/);
+  });
+
+  it("caches OrganizationId across multiple invocations (only one /WhoAmI call total)", async () => {
+    const server = createMockServer();
+    const client = makeClient();
+    registerSchemaTools(server as any, client);
+
+    const tool = server.tools.get("get_attribute_dependencies_list_url")!;
+    await tool.handler({
+      entity_logical_name: "e",
+      attribute_logical_name: "a",
+    });
+    await tool.handler({
+      entity_logical_name: "e2",
+      attribute_logical_name: "a2",
+    });
+    await tool.handler({
+      entity_logical_name: "e3",
+      attribute_logical_name: "a3",
+    });
+
+    const whoamiCalls = client.get.mock.calls.filter(
+      ([p]: [string]) => p === "/WhoAmI",
+    );
+    expect(whoamiCalls).toHaveLength(1);
+  });
+
+  it("escapes single quotes in logical names (OData injection)", async () => {
+    const server = createMockServer();
+    const client = makeClient();
+    registerSchemaTools(server as any, client);
+
+    await server.tools
+      .get("get_attribute_dependencies_list_url")!
+      .handler({
+        entity_logical_name: "weird'entity",
+        attribute_logical_name: "odd'col",
+      });
+
+    const paths = client.get.mock.calls.map(([p]: [string]) => p);
+    expect(paths).toContain(
+      "/EntityDefinitions(LogicalName='weird''entity')?$select=MetadataId",
+    );
+    expect(paths).toContain(
+      "/EntityDefinitions(LogicalName='weird''entity')/Attributes(LogicalName='odd''col')?$select=MetadataId",
+    );
+  });
+
+  it("throws if the attribute lookup returns no MetadataId", async () => {
+    const server = createMockServer();
+    const client = makeClient({ attr: {} });
+    registerSchemaTools(server as any, client);
+
+    await expect(
+      server.tools.get("get_attribute_dependencies_list_url")!.handler({
+        entity_logical_name: "fundai_x",
+        attribute_logical_name: "missing_attr",
+      }),
+    ).rejects.toThrow(/Attribute not found: fundai_x\.missing_attr/);
+  });
+
+  it("throws if WhoAmI omits OrganizationId", async () => {
+    const server = createMockServer();
+    const client = makeClient({ whoami: {} });
+    registerSchemaTools(server as any, client);
+
+    await expect(
+      server.tools.get("get_attribute_dependencies_list_url")!.handler({
+        entity_logical_name: "e",
+        attribute_logical_name: "a",
+      }),
+    ).rejects.toThrow(/OrganizationId/);
   });
 });


### PR DESCRIPTION
Closes #27.

## Summary
New tool **\`get_attribute_dependencies\`** — when \`delete_attribute\` fails with \`0x8004f01f\` (\"referenced by N other components\"), returns a structured list of components (forms, views, workflows, business rules, plugins, …) that reference the column. Backed by the Dataverse \`RetrieveDependenciesForDelete\` function.

## Output

\`\`\`json
[
  {
    \"component_type\": 60,
    \"component_type_name\": \"SystemForm\",
    \"object_id\": \"...guid...\",
    \"name\": \"Information\"
  },
  {
    \"component_type\": 26,
    \"component_type_name\": \"SavedQuery\",
    \"object_id\": \"...guid...\",
    \"name\": \"Active ACH Transactions\"
  }
]
\`\`\`

## Implementation
- \`componenttype\` int → friendly name table covers ~30 types most likely to surface as attribute deps. Unknown ints → \`ComponentType_<N>\` (caller still sees the raw value).
- Best-effort name resolution: dependencies are grouped by component type and resolved in parallel batches against their respective entity sets (\`systemforms\`, \`savedqueries\`, \`workflows\`, \`reports\`, \`webresourceset\`, \`fieldsecurityprofiles\`, \`appmodules\`, \`sdkmessageprocessingsteps\`). One HTTP call per type, not per dep.
- Component types without a resolver keep \`name: null\` (caller still has the raw \`object_id\` to drill down via \`query_records\`).

## Design history (why URL-only got abandoned)
The first iteration of this PR returned a Power Apps maker UI deep-link instead. Live testing showed the URL pattern needs the Power Platform **EnvironmentId**, which is distinct from the Dataverse **OrganizationId** returned by \`/WhoAmI\`. Getting EnvironmentId requires a separate Power Platform Admin API with different OAuth scopes — expanding the package's auth surface for one tool. Pivoted to the structured listing, which works fully within the existing Dataverse Web API auth.

## Test plan
- [x] \`npm run lint\` / \`npm run build\` clean
- [x] 98 unit tests pass (+7 new): structured output shape, batched name resolution per type, ComponentType_<N> fallback, empty deps, attribute-not-found error, OData injection escaping, dep order preservation across batched resolution
- [ ] **Live test after restart** (requires Claude Code restart for MCP to pick up the new tool): call on \`fundai_achtransaction.fundai_settledat\`, verify structured deps list returns

## Version
0.3.0 — minor bump (new public tool surface, backward compatible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)