### PR TITLE
fix: map 404 from metadata GET to 'Attribute not found' in get_attribute_dependencies

### DIFF
--- a/src/tools/schema-tools.ts
+++ b/src/tools/schema-tools.ts
@@ -773,10 +773,25 @@ export function registerSchemaTools(
       const attrPath = `/EntityDefinitions(LogicalName='${entityEscaped}')/Attributes(LogicalName='${attrEscaped}')`;
 
       // Step 1: resolve attribute MetadataId (RetrieveDependenciesForDelete
-      // takes the raw GUID, not a logical-name lookup).
-      const attrResult = (await client.get(
-        `${attrPath}?$select=MetadataId`,
-      )) as { MetadataId?: string };
+      // takes the raw GUID, not a logical-name lookup). Dataverse returns 404
+      // when the entity or attribute logical name doesn't exist; map that to a
+      // friendly message instead of leaking the raw "Dataverse API error (404)".
+      let attrResult: { MetadataId?: string };
+      try {
+        attrResult = (await client.get(`${attrPath}?$select=MetadataId`)) as {
+          MetadataId?: string;
+        };
+      } catch (err) {
+        if (
+          err instanceof Error &&
+          /Dataverse API error \(404\)/.test(err.message)
+        ) {
+          throw new Error(
+            `Attribute not found: ${entity_logical_name}.${attribute_logical_name}`,
+          );
+        }
+        throw err;
+      }
       if (!attrResult.MetadataId) {
         throw new Error(
           `Attribute not found: ${entity_logical_name}.${attribute_logical_name}`,

--- a/tests/schema-tools.test.ts
+++ b/tests/schema-tools.test.ts
@@ -780,9 +780,18 @@ describe("get_attribute_dependencies", () => {
     expect(JSON.parse(result.content[0].text)).toEqual([]);
   });
 
-  it("throws if the attribute lookup returns no MetadataId", async () => {
+  it("maps a 404 from the metadata GET to a friendly 'Attribute not found' error", async () => {
     const server = createMockServer();
-    const client = makeClient({ attrResponse: {} });
+    // DataverseClient throws `Error("Dataverse API error (404): ...")` on a
+    // missing entity/attribute logical name — that's what reaches the tool in
+    // production, not a 200 with an empty body.
+    const client = {
+      get: vi.fn().mockRejectedValue(
+        new Error(
+          'Dataverse API error (404): {"error":{"code":"0x80060888","message":"Resource not found"}}',
+        ),
+      ),
+    } as any;
     registerSchemaTools(server as any, client);
 
     await expect(
@@ -791,6 +800,23 @@ describe("get_attribute_dependencies", () => {
         attribute_logical_name: "missing_attr",
       }),
     ).rejects.toThrow(/Attribute not found: fundai_x\.missing_attr/);
+  });
+
+  it("rethrows non-404 client errors verbatim (e.g. 500)", async () => {
+    const server = createMockServer();
+    const client = {
+      get: vi
+        .fn()
+        .mockRejectedValue(new Error("Dataverse API error (500): boom")),
+    } as any;
+    registerSchemaTools(server as any, client);
+
+    await expect(
+      server.tools.get("get_attribute_dependencies")!.handler({
+        entity_logical_name: "e",
+        attribute_logical_name: "a",
+      }),
+    ).rejects.toThrow(/Dataverse API error \(500\): boom/);
   });
 
   it("escapes single quotes in logical names (OData injection)", async () => {


### PR DESCRIPTION
## Summary
- `get_attribute_dependencies` only checked `MetadataId` on a 200 response, but `DataverseClient` throws `Error("Dataverse API error (404): ...")` first when the entity/attribute logical name doesn't exist — so users saw the raw 404 string instead of `Attribute not found: <entity>.<attribute>`. Catch the 404 and re-throw the friendly message; non-404 errors pass through.
- Replaced the not-found test that mocked `{}` (which never happens in production) with one that rejects with the real 404 error shape; added a 500 test to confirm other errors are not re-mapped.

Addresses unfixed [Copilot review](https://github.com/rededis/dataverse-mcp-server/pull/28#pullrequestreview-4175234960) comments from #28:
- [discussion_r3141593579](https://github.com/rededis/dataverse-mcp-server/pull/28#discussion_r3141593579) — 404 from `client.get` bypasses the friendly-message branch.
- [discussion_r3141593596](https://github.com/rededis/dataverse-mcp-server/pull/28#discussion_r3141593596) — test simulated not-found as 200 + `{}`, not the real 404 path.

The other three Copilot comments on #28 are obsolete — the WhoAmI/OrganizationId cache and Power Apps maker URL the tool returned were removed before merge, so concurrency, hard-coded `make.powerapps.com`, and the test-only `_resetOrganizationIdCache` export no longer apply.

## Test plan
- [x] `npm test` — 99 tests pass (incl. new 404 mapping + 500 passthrough cases)
- [x] `npm run lint`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)