### PR TITLE
Add GitHub Actions workflow for npm publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          cache: npm
+
+      - run: npm ci
+
+      - name: Verify package.json version matches release tag
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG="$(node -p "require('./package.json').version")"
+          if [ "$TAG" != "$PKG" ]; then
+            echo "::error::Release tag ${GITHUB_REF_NAME} (-> ${TAG}) does not match package.json version (${PKG})"
+            exit 1
+          fi
+
+      - name: Verify CHANGELOG has entry for this version
+        run: |
+          PKG="$(node -p "require('./package.json').version")"
+          if ! grep -q "^## \[${PKG}\]" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md is missing a '## [${PKG}]' section"
+            exit 1
+          fi
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Verify CHANGELOG has entry for this version
         run: |
           PKG="$(node -p "require('./package.json').version")"
-          if ! grep -q "^## \[${PKG}\]" CHANGELOG.md; then
+          if ! grep -Fq "## [${PKG}]" CHANGELOG.md; then
             echo "::error::CHANGELOG.md is missing a '## [${PKG}]' section"
             exit 1
           fi


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` to automate npm publish on GitHub Release.
- Triggers on `release: published`; guards against tag/`package.json` version mismatch and missing `CHANGELOG.md` entry.
- Runs lint/test/build before publish; uses npm provenance (`id-token: write`).

## How it'll be used
1. Bump `version` in `package.json` and add a `## [X.Y.Z]` section to `CHANGELOG.md`.
2. Merge to `main`.
3. Create a GitHub Release with tag `vX.Y.Z` (must match `package.json`) → workflow publishes to npm.

## Setup
- Repo secret `NPM_TOKEN` is already configured.
- Package is public scoped (`@rededis/dataverse-mcp-server`); workflow uses `--provenance --access public`.

## Test plan
- [ ] After merge, do a real `0.3.1` test release end-to-end to validate the workflow before relying on it for future releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)