### PR TITLE
Release 0.3.1: get_attribute_dependencies 404 fix + npm publish automation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-04-25
+
+### Fixed
+
+- `get_attribute_dependencies`: a missing entity or attribute now surfaces as the friendly `Attribute not found: <entity>.<attribute>` error instead of the raw `Dataverse API error (404): ...` (#30).
+
+### Changed
+
+- CI: npm publish is now automated via a GitHub Actions release workflow that triggers on GitHub Release publication. Guards verify that the release tag matches `package.json` version and that `CHANGELOG.md` has a matching section before running lint/test/build and publishing with npm provenance (#31).
+
 ## [0.3.0] - 2026-04-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rededis/dataverse-mcp-server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "MCP server for Microsoft Dataverse API",
   "main": "dist/index.js",
   "bin": {


### PR DESCRIPTION
## Summary

Patch release bundling two changes that landed on `main` since 0.3.0:

- **#30** — `get_attribute_dependencies` now returns a friendly `Attribute not found: <entity>.<attribute>` instead of the raw `Dataverse API error (404): ...` when the target metadata is missing.
- **#31** — npm publish is now automated by a GitHub Actions release workflow that fires on GitHub Release publication, with guards on tag/`package.json` version match and CHANGELOG presence.

## Why 0.3.1 (patch)

Both changes are patch-level — the bugfix doesn't change the tool's input schema or success contract, and the CI automation has no effect on the published artifact's runtime behavior.

## Test plan

- [x] `npm run lint && npm test && npm run build` — all green locally (99 tests pass).
- [ ] After merge, create GitHub Release `v0.3.1` to trigger the new release workflow and verify the package lands on npm with provenance (this is also the first end-to-end exercise of the automation from #31).

🤖 Generated with [Claude Code](https://claude.com/claude-code)