### PR TITLE
Fix release workflow: sync lockfile + use npm install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: npm
 
-      - run: npm ci
+      - run: npm install --no-audit --no-fund
 
       - name: Verify package.json version matches release tag
         run: |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rededis/dataverse-mcp-server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rededis/dataverse-mcp-server",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",


### PR DESCRIPTION
## Summary

Fixes the v0.3.1 release that failed at the `npm ci` step. Two related fixes:

1. **Sync `package-lock.json`** with the 0.3.1 version bump from #32. The root version field was stale (still `0.3.0`).
2. **Switch `release.yml` from `npm ci` to `npm install`**. macOS-generated lockfiles never contain linux-only optional native deps (e.g. `@biomejs/cli-linux-*` and their `@emnapi/*` bindings), so `npm ci` on Ubuntu runners always fails. `ci.yml` already uses `npm install` for the same reason.

## Why not "fix the lockfile properly"

Generating a truly cross-platform lockfile requires running `npm install` inside a Linux container — every subsequent `npm install` on macOS would re-break it. Trade-off not worth it for a single-binary publish workflow whose dependency resolution is already validated by `ci.yml`.

## After merge

The failed `v0.3.1` GitHub Release and tag have already been deleted. After this PR merges, recreate `v0.3.1` against the new HEAD to re-trigger the release workflow.

## Test plan

- [x] `npm run lint && npm test && npm run build` locally — green.
- [x] `npm ci` now passes on macOS (lockfile internally consistent for this platform).
- [ ] After merge, `gh release create v0.3.1` should succeed end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)