### PR TITLE
Add invoke_action / invoke_function tools (closes #57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-16
+
+### Added
+
+- Two new tools for invoking Dataverse Web API actions and functions, covering operations that fall outside CRUD (closes #57):
+  - `invoke_action(name, entity_set?, id?, parameters?)` — POSTs a bound or unbound action. Unbound → `POST /<name>` (e.g. `UnpublishDuplicateRule` with `{ DuplicateRuleId }`); bound → `POST /<entity_set>(<id>)/Microsoft.Dynamics.CRM.<name>` (e.g. `PublishDuplicateRule` bound to `duplicaterule`, `QualifyLead` bound to `lead`). `parameters` is sent as the JSON request body. Bound-vs-unbound is per the Web API `$metadata`, not the SDK shape — verified live against a real org.
+  - `invoke_function(name, entity_set?, id?, parameters?)` — GETs a bound or unbound function (e.g. `WhoAmI`). `parameters` are inlined as OData function arguments using parameter aliases; strings are quoted, GUIDs/numbers/booleans passed as-is.
+  - Bare operation names are namespaced automatically for bound calls (`Microsoft.Dynamics.CRM.<name>`); a fully-qualified name is passed through. Operation names are validated against a dotted-identifier pattern and bound `id` must be a GUID, so a caller cannot inject extra path/query segments. Bound calls require both `entity_set` and `id`; unbound calls require neither (the half-specified case is rejected).
+
+### Use case
+
+Unblocks CRM operations that are only exposed as actions — notably publishing duplicate-detection rules (a rule created via `create_record` lands unpublished and has no effect until `PublishDuplicateRule`) and lead qualification (`QualifyLead`). Surfaced while building the fundaicapital Lead→Account qualification flow (DP-129 / DP-135).
+
+### Note
+
+`invoke_action` can perform arbitrary mutating operations and is intentionally ungated for now; capability-based access control (safe-by-default gating of writes/actions) is tracked separately in #45 / #46. `invoke_function` is read-only.
+
 ## [0.4.0] - 2026-05-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,6 +50,33 @@ MCP (Model Context Protocol) server for Microsoft Dataverse API with [safe-by-de
 
 Picklist tools accept either `entity_logical_name` + `attribute_logical_name` (Local OptionSet) or `option_set_name` (Global OptionSet) — the two modes are mutually exclusive. Write operations require Customizer or System Administrator role on the connected service principal. Deleting an option does **not** update existing records that hold its numeric value — they are left with an orphan integer.
 
+### Actions & functions
+| Tool | Description |
+|------|-------------|
+| `invoke_action` | Invoke a Web API **action** (POST), bound or unbound — for operations outside plain CRUD (e.g. `PublishDuplicateRule`, `QualifyLead`) |
+| `invoke_function` | Invoke a Web API **function** (GET), bound or unbound — read-only operations exposed as functions (e.g. `WhoAmI`) |
+
+Pass `entity_set` + `id` for a **bound** call (`POST /<entity_set>(<id>)/Microsoft.Dynamics.CRM.<name>`); omit both for an **unbound** call (`POST /<name>`). For `invoke_action`, `parameters` is the JSON request body; for `invoke_function`, `parameters` is inlined as OData function arguments. Bare operation names are namespaced automatically for bound calls — pass a fully-qualified name to override.
+
+Examples:
+
+```jsonc
+// Publish a draft duplicate-detection rule.
+// PublishDuplicateRule is a BOUND action on duplicaterule (returns an async job).
+invoke_action({ name: "PublishDuplicateRule", entity_set: "duplicaterules", id: "<guid>" })
+
+// Unpublish is an UNBOUND action taking DuplicateRuleId — note the asymmetry.
+invoke_action({ name: "UnpublishDuplicateRule", parameters: { DuplicateRuleId: "<guid>" } })
+
+// Qualify a lead into Account/Contact/Opportunity (bound action on lead).
+invoke_action({ name: "QualifyLead", entity_set: "leads", id: "<guid>",
+                parameters: { CreateAccount: true, CreateContact: true, CreateOpportunity: true, Status: 3 } })
+```
+
+> Whether an operation is bound or unbound is defined in the Web API `$metadata`, not by intuition — e.g. `PublishDuplicateRule` is bound but `UnpublishDuplicateRule` is unbound. Check `$metadata` (look for `IsBound="true"` and the binding `Parameter`) if a call returns `404 "Resource not found for the segment"`.
+
+> ⚠️ `invoke_action` can perform arbitrary mutating operations. It is currently **ungated** by design; capability-based access control (a safe-by-default policy gating writes/actions) is tracked separately in [#45 / #46](https://github.com/rededis/dataverse-mcp-server/issues/45). `invoke_function` is read-only.
+
 ## Quick start (no clone)
 
 Add to `.mcp.json` in your project root:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@rededis/dataverse-mcp-server",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@rededis/dataverse-mcp-server",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rededis/dataverse-mcp-server",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "MCP server for Microsoft Dataverse API",
   "main": "dist/index.js",
   "bin": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { config } from "dotenv";
 import { DataverseAuth } from "./auth.js";
 import { DataverseClient } from "./client.js";
+import { registerActionTools } from "./tools/action-tools.js";
 import { registerDataTools } from "./tools/data-tools.js";
 import { registerPicklistTools } from "./tools/picklist-tools.js";
 import { registerSchemaTools } from "./tools/schema-tools.js";
@@ -87,6 +88,7 @@ if (missing.length > 0) {
   registerDataTools(server, client, entityPrefix, allowDelete, solutionName);
   registerSchemaTools(server, client, allowDelete);
   registerPicklistTools(server, client, allowDelete);
+  registerActionTools(server, client);
 }
 
 const transport = new StdioServerTransport();

--- a/src/tools/action-tools.ts
+++ b/src/tools/action-tools.ts
@@ -1,0 +1,170 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { z } from "zod";
+import type { DataverseClient } from "../client.js";
+
+// Operation names are restricted to dotted identifiers so a caller can never
+// smuggle a path segment, query string, or quote into the request URL.
+const OPERATION_NAME = /^[A-Za-z][A-Za-z0-9_]*(\.[A-Za-z][A-Za-z0-9_]*)*$/;
+const GUID = /^\{?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}\}?$/;
+const CRM_NAMESPACE = "Microsoft.Dynamics.CRM.";
+
+/**
+ * Bound operations need the `Microsoft.Dynamics.CRM.` namespace prefix; unbound
+ * ones (system functions like WhoAmI, and custom process actions like
+ * `new_MyAction`) are called by their plain name. A name that already carries a
+ * namespace (contains a dot) is passed through untouched.
+ */
+export function qualifyOperationName(name: string, bound: boolean): string {
+  if (!bound || name.includes(".")) return name;
+  return `${CRM_NAMESPACE}${name}`;
+}
+
+/**
+ * Decide bound-vs-unbound and reject the half-specified case. Bound calls need
+ * BOTH entity_set and id; unbound calls need NEITHER.
+ */
+export function resolveBinding(entitySet?: string, id?: string): boolean {
+  const hasSet = entitySet !== undefined && entitySet !== "";
+  const hasId = id !== undefined && id !== "";
+  if (hasSet !== hasId) {
+    throw new Error(
+      "Inconsistent binding: a bound call requires both entity_set and id; an unbound call requires neither.",
+    );
+  }
+  if (hasSet && id !== undefined && !GUID.test(id)) {
+    throw new Error(`Invalid record id (expected a GUID): ${id}`);
+  }
+  return hasSet;
+}
+
+function assertValidName(name: string): void {
+  if (!OPERATION_NAME.test(name)) {
+    throw new Error(
+      `Invalid operation name: '${name}'. Use the bare operation name (e.g. 'QualifyLead', 'PublishDuplicateRule') or a fully-qualified name.`,
+    );
+  }
+}
+
+/** Format a single value as an OData literal for inline function parameters. */
+export function formatODataLiteral(value: unknown): string {
+  if (value === null || value === undefined) return "null";
+  if (typeof value === "string") {
+    return GUID.test(value) ? value : `'${value.replace(/'/g, "''")}'`;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  // Edm complex/collection values are passed as JSON.
+  return JSON.stringify(value);
+}
+
+/**
+ * Build the function-call URL segment using parameter aliases, e.g.
+ * `FnName(P1=@p1,P2=@p2)?@p1='x'&@p2=42`. With no parameters the bare operation
+ * name is used (`WhoAmI`), which Dataverse accepts for parameterless functions.
+ */
+export function buildFunctionCall(
+  opName: string,
+  parameters?: Record<string, unknown>,
+): string {
+  const keys = parameters ? Object.keys(parameters) : [];
+  if (keys.length === 0) return opName;
+  const paramList = keys.map((k) => `${k}=@${k}`).join(",");
+  const aliasList = keys
+    .map(
+      (k) =>
+        `@${k}=${encodeURIComponent(formatODataLiteral((parameters as Record<string, unknown>)[k]))}`,
+    )
+    .join("&");
+  return `${opName}(${paramList})?${aliasList}`;
+}
+
+export function registerActionTools(
+  server: McpServer,
+  client: DataverseClient,
+): void {
+  server.tool(
+    "invoke_action",
+    "Invoke a Dataverse Web API action (POST) — bound or unbound. Use for operations that are not plain CRUD, e.g. PublishDuplicateRule/UnpublishDuplicateRule (unbound) or QualifyLead (bound to a lead). Pass entity_set+id for bound actions, neither for unbound. parameters becomes the JSON request body.",
+    {
+      name: z
+        .string()
+        .describe(
+          "Action name, e.g. 'PublishDuplicateRule', 'QualifyLead'. Bare names are namespaced automatically for bound calls; pass a fully-qualified name to override.",
+        ),
+      entity_set: z
+        .string()
+        .optional()
+        .describe(
+          "Entity set (plural, e.g. 'leads') for a bound action. Omit for unbound actions.",
+        ),
+      id: z
+        .string()
+        .optional()
+        .describe(
+          "Record GUID the bound action targets. Required iff entity_set is set.",
+        ),
+      parameters: z
+        .record(z.string(), z.unknown())
+        .optional()
+        .describe(
+          "Action parameters sent as the JSON request body (e.g. { DuplicateRuleId } for PublishDuplicateRule, { CreateAccount, CreateContact, Status } for QualifyLead).",
+        ),
+    },
+    async ({ name, entity_set, id, parameters }) => {
+      assertValidName(name);
+      const bound = resolveBinding(entity_set, id);
+      const opName = qualifyOperationName(name, bound);
+      const path = bound ? `/${entity_set}(${id})/${opName}` : `/${opName}`;
+      const result = await client.post(path, parameters ?? {});
+      return {
+        content: [
+          { type: "text" as const, text: JSON.stringify(result, null, 2) },
+        ],
+      };
+    },
+  );
+
+  server.tool(
+    "invoke_function",
+    "Invoke a Dataverse Web API function (GET) — bound or unbound. Use for read-only operations exposed as functions, e.g. WhoAmI (unbound) or RetrieveDuplicates. Pass entity_set+id for bound functions, neither for unbound. parameters are inlined into the URL as OData function arguments.",
+    {
+      name: z
+        .string()
+        .describe(
+          "Function name, e.g. 'WhoAmI'. Bare names are namespaced automatically for bound calls; pass a fully-qualified name to override.",
+        ),
+      entity_set: z
+        .string()
+        .optional()
+        .describe(
+          "Entity set (plural) for a bound function. Omit for unbound functions.",
+        ),
+      id: z
+        .string()
+        .optional()
+        .describe(
+          "Record GUID the bound function targets. Required iff entity_set is set.",
+        ),
+      parameters: z
+        .record(z.string(), z.unknown())
+        .optional()
+        .describe(
+          "Function parameters, inlined as OData arguments. Strings are quoted, GUIDs/numbers/booleans passed as-is.",
+        ),
+    },
+    async ({ name, entity_set, id, parameters }) => {
+      assertValidName(name);
+      const bound = resolveBinding(entity_set, id);
+      const opName = qualifyOperationName(name, bound);
+      const fnCall = buildFunctionCall(opName, parameters);
+      const path = bound ? `/${entity_set}(${id})/${fnCall}` : `/${fnCall}`;
+      const result = await client.get(path);
+      return {
+        content: [
+          { type: "text" as const, text: JSON.stringify(result, null, 2) },
+        ],
+      };
+    },
+  );
+}

--- a/src/tools/action-tools.ts
+++ b/src/tools/action-tools.ts
@@ -5,6 +5,9 @@ import type { DataverseClient } from "../client.js";
 // Operation names are restricted to dotted identifiers so a caller can never
 // smuggle a path segment, query string, or quote into the request URL.
 const OPERATION_NAME = /^[A-Za-z][A-Za-z0-9_]*(\.[A-Za-z][A-Za-z0-9_]*)*$/;
+// Function parameter names are interpolated into the URL (`Fn(P=@P)?@P=...`),
+// so they are held to the same identifier restriction to prevent URL injection.
+const PARAM_NAME = /^[A-Za-z][A-Za-z0-9_]*$/;
 const GUID = /^\{?[0-9a-fA-F]{8}-([0-9a-fA-F]{4}-){3}[0-9a-fA-F]{12}\}?$/;
 const CRM_NAMESPACE = "Microsoft.Dynamics.CRM.";
 
@@ -69,6 +72,13 @@ export function buildFunctionCall(
 ): string {
   const keys = parameters ? Object.keys(parameters) : [];
   if (keys.length === 0) return opName;
+  for (const k of keys) {
+    if (!PARAM_NAME.test(k)) {
+      throw new Error(
+        `Invalid parameter name: '${k}'. Parameter names must be identifiers (letters, digits, underscore; starting with a letter).`,
+      );
+    }
+  }
   const paramList = keys.map((k) => `${k}=@${k}`).join(",");
   const aliasList = keys
     .map(
@@ -85,7 +95,7 @@ export function registerActionTools(
 ): void {
   server.tool(
     "invoke_action",
-    "Invoke a Dataverse Web API action (POST) — bound or unbound. Use for operations that are not plain CRUD, e.g. PublishDuplicateRule/UnpublishDuplicateRule (unbound) or QualifyLead (bound to a lead). Pass entity_set+id for bound actions, neither for unbound. parameters becomes the JSON request body.",
+    "Invoke a Dataverse Web API action (POST) — bound or unbound. Use for operations that are not plain CRUD, e.g. PublishDuplicateRule (bound to a duplicaterule) or QualifyLead (bound to a lead), or UnpublishDuplicateRule (unbound, takes DuplicateRuleId). Whether an action is bound is defined in the Web API $metadata. Pass entity_set+id for bound actions, neither for unbound. parameters becomes the JSON request body.",
     {
       name: z
         .string()

--- a/tests/action-tools.test.ts
+++ b/tests/action-tools.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildFunctionCall,
+  formatODataLiteral,
+  qualifyOperationName,
+  registerActionTools,
+  resolveBinding,
+} from "../src/tools/action-tools.js";
+
+function createMockServer() {
+  const tools = new Map<string, { description: string; handler: Function }>();
+  return {
+    tool: vi.fn(
+      (
+        name: string,
+        description: string,
+        _schema: unknown,
+        handler: Function,
+      ) => {
+        tools.set(name, { description, handler });
+      },
+    ),
+    tools,
+  };
+}
+
+const GUID = "11111111-1111-1111-1111-111111111111";
+
+describe("helpers", () => {
+  it("qualifies bound operation names with the CRM namespace", () => {
+    expect(qualifyOperationName("QualifyLead", true)).toBe(
+      "Microsoft.Dynamics.CRM.QualifyLead",
+    );
+  });
+
+  it("leaves unbound names and already-qualified names untouched", () => {
+    expect(qualifyOperationName("WhoAmI", false)).toBe("WhoAmI");
+    expect(qualifyOperationName("Microsoft.Dynamics.CRM.X", true)).toBe(
+      "Microsoft.Dynamics.CRM.X",
+    );
+  });
+
+  it("resolveBinding returns true for bound, false for unbound", () => {
+    expect(resolveBinding("leads", GUID)).toBe(true);
+    expect(resolveBinding(undefined, undefined)).toBe(false);
+    expect(resolveBinding("", "")).toBe(false);
+  });
+
+  it("resolveBinding rejects half-specified bindings", () => {
+    expect(() => resolveBinding("leads", undefined)).toThrow(
+      /Inconsistent binding/,
+    );
+    expect(() => resolveBinding(undefined, GUID)).toThrow(
+      /Inconsistent binding/,
+    );
+  });
+
+  it("resolveBinding rejects a non-GUID id", () => {
+    expect(() => resolveBinding("leads", "not-a-guid")).toThrow(
+      /Invalid record id/,
+    );
+  });
+
+  it("formats OData literals by type", () => {
+    expect(formatODataLiteral("hello")).toBe("'hello'");
+    expect(formatODataLiteral("O'Brien")).toBe("'O''Brien'");
+    expect(formatODataLiteral(GUID)).toBe(GUID); // GUIDs are unquoted
+    expect(formatODataLiteral(42)).toBe("42");
+    expect(formatODataLiteral(true)).toBe("true");
+    expect(formatODataLiteral(null)).toBe("null");
+  });
+
+  it("builds parameterless and parameterized function calls", () => {
+    expect(buildFunctionCall("WhoAmI")).toBe("WhoAmI");
+    // encodeURIComponent leaves the apostrophe unescaped (it is URL-safe).
+    expect(buildFunctionCall("GetX", { Name: "abc", Top: 5 })).toBe(
+      "GetX(Name=@Name,Top=@Top)?@Name='abc'&@Top=5",
+    );
+  });
+});
+
+describe("invoke_action", () => {
+  it("posts an unbound action to /<name> with parameters as body", async () => {
+    const server = createMockServer();
+    const client = { post: vi.fn().mockResolvedValue({ ok: true }) } as any;
+    registerActionTools(server as any, client);
+
+    const result = await server.tools
+      .get("invoke_action")!
+      .handler({ name: "PublishDuplicateRule", parameters: { DuplicateRuleId: GUID } });
+
+    expect(client.post).toHaveBeenCalledWith("/PublishDuplicateRule", {
+      DuplicateRuleId: GUID,
+    });
+    expect(result.content[0].text).toContain("true");
+  });
+
+  it("posts a bound action to /<set>(<id>)/Microsoft.Dynamics.CRM.<name>", async () => {
+    const server = createMockServer();
+    const client = { post: vi.fn().mockResolvedValue({}) } as any;
+    registerActionTools(server as any, client);
+
+    await server.tools
+      .get("invoke_action")!
+      .handler({
+        name: "QualifyLead",
+        entity_set: "leads",
+        id: GUID,
+        parameters: { CreateAccount: true },
+      });
+
+    expect(client.post).toHaveBeenCalledWith(
+      `/leads(${GUID})/Microsoft.Dynamics.CRM.QualifyLead`,
+      { CreateAccount: true },
+    );
+  });
+
+  it("sends an empty body when no parameters are given", async () => {
+    const server = createMockServer();
+    const client = { post: vi.fn().mockResolvedValue({}) } as any;
+    registerActionTools(server as any, client);
+
+    await server.tools.get("invoke_action")!.handler({ name: "WhoAmI" });
+    expect(client.post).toHaveBeenCalledWith("/WhoAmI", {});
+  });
+
+  it("rejects an invalid operation name", async () => {
+    const server = createMockServer();
+    const client = { post: vi.fn() } as any;
+    registerActionTools(server as any, client);
+
+    await expect(
+      server.tools.get("invoke_action")!.handler({ name: "../accounts" }),
+    ).rejects.toThrow(/Invalid operation name/);
+    expect(client.post).not.toHaveBeenCalled();
+  });
+
+  it("rejects a half-specified binding", async () => {
+    const server = createMockServer();
+    const client = { post: vi.fn() } as any;
+    registerActionTools(server as any, client);
+
+    await expect(
+      server.tools
+        .get("invoke_action")!
+        .handler({ name: "QualifyLead", entity_set: "leads" }),
+    ).rejects.toThrow(/Inconsistent binding/);
+    expect(client.post).not.toHaveBeenCalled();
+  });
+});
+
+describe("invoke_function", () => {
+  it("gets an unbound parameterless function from /<name>", async () => {
+    const server = createMockServer();
+    const client = {
+      get: vi.fn().mockResolvedValue({ UserId: GUID }),
+    } as any;
+    registerActionTools(server as any, client);
+
+    const result = await server.tools
+      .get("invoke_function")!
+      .handler({ name: "WhoAmI" });
+
+    expect(client.get).toHaveBeenCalledWith("/WhoAmI");
+    expect(result.content[0].text).toContain(GUID);
+  });
+
+  it("inlines parameters into a bound function URL", async () => {
+    const server = createMockServer();
+    const client = { get: vi.fn().mockResolvedValue({ value: [] }) } as any;
+    registerActionTools(server as any, client);
+
+    await server.tools
+      .get("invoke_function")!
+      .handler({
+        name: "RetrieveX",
+        entity_set: "accounts",
+        id: GUID,
+        parameters: { Top: 3 },
+      });
+
+    expect(client.get).toHaveBeenCalledWith(
+      `/accounts(${GUID})/Microsoft.Dynamics.CRM.RetrieveX(Top=@Top)?@Top=3`,
+    );
+  });
+});

--- a/tests/action-tools.test.ts
+++ b/tests/action-tools.test.ts
@@ -80,6 +80,8 @@ describe("helpers", () => {
 });
 
 describe("invoke_action", () => {
+  // UnpublishDuplicateRule is genuinely unbound (takes DuplicateRuleId);
+  // PublishDuplicateRule, by contrast, is bound — see the bound test below.
   it("posts an unbound action to /<name> with parameters as body", async () => {
     const server = createMockServer();
     const client = { post: vi.fn().mockResolvedValue({ ok: true }) } as any;
@@ -87,9 +89,12 @@ describe("invoke_action", () => {
 
     const result = await server.tools
       .get("invoke_action")!
-      .handler({ name: "PublishDuplicateRule", parameters: { DuplicateRuleId: GUID } });
+      .handler({
+        name: "UnpublishDuplicateRule",
+        parameters: { DuplicateRuleId: GUID },
+      });
 
-    expect(client.post).toHaveBeenCalledWith("/PublishDuplicateRule", {
+    expect(client.post).toHaveBeenCalledWith("/UnpublishDuplicateRule", {
       DuplicateRuleId: GUID,
     });
     expect(result.content[0].text).toContain("true");
@@ -112,6 +117,27 @@ describe("invoke_action", () => {
     expect(client.post).toHaveBeenCalledWith(
       `/leads(${GUID})/Microsoft.Dynamics.CRM.QualifyLead`,
       { CreateAccount: true },
+    );
+  });
+
+  // PublishDuplicateRule is bound to duplicaterule (verified live), so it must
+  // be invoked on the entity, not at the service root.
+  it("posts bound PublishDuplicateRule to the duplicaterule entity", async () => {
+    const server = createMockServer();
+    const client = { post: vi.fn().mockResolvedValue({}) } as any;
+    registerActionTools(server as any, client);
+
+    await server.tools
+      .get("invoke_action")!
+      .handler({
+        name: "PublishDuplicateRule",
+        entity_set: "duplicaterules",
+        id: GUID,
+      });
+
+    expect(client.post).toHaveBeenCalledWith(
+      `/duplicaterules(${GUID})/Microsoft.Dynamics.CRM.PublishDuplicateRule`,
+      {},
     );
   });
 
@@ -163,6 +189,19 @@ describe("invoke_function", () => {
 
     expect(client.get).toHaveBeenCalledWith("/WhoAmI");
     expect(result.content[0].text).toContain(GUID);
+  });
+
+  it("rejects a parameter name that could inject into the URL", async () => {
+    const server = createMockServer();
+    const client = { get: vi.fn() } as any;
+    registerActionTools(server as any, client);
+
+    await expect(
+      server.tools
+        .get("invoke_function")!
+        .handler({ name: "GetX", parameters: { "Bad)&$top": 1 } }),
+    ).rejects.toThrow(/Invalid parameter name/);
+    expect(client.get).not.toHaveBeenCalled();
   });
 
   it("inlines parameters into a bound function URL", async () => {


### PR DESCRIPTION
## What

Adds two generic tools for invoking Dataverse Web API operations that fall outside CRUD:

- **`invoke_action`** — POST a bound or unbound **action** (e.g. `PublishDuplicateRule`, `UnpublishDuplicateRule`, `QualifyLead`).
- **`invoke_function`** — GET a bound or unbound **function** (e.g. `WhoAmI`).

Bound calls hit `/<entity_set>(<id>)/Microsoft.Dynamics.CRM.<name>`; unbound calls hit `/<name>`. Bare operation names are namespaced automatically for bound calls; fully-qualified names pass through. `invoke_action` sends `parameters` as the JSON body; `invoke_function` inlines them as OData function arguments via parameter aliases.

Closes #57.

## Why

Several CRM operations are **only** available as actions and were impossible via MCP — notably publishing duplicate-detection rules (a rule created via `create_record` lands unpublished and has no effect until `PublishDuplicateRule`) and lead qualification (`QualifyLead`). Surfaced building the fundaicapital Lead→Account flow (DP-129 / DP-135).

## Input hardening

- Operation name restricted to a dotted-identifier pattern; bound `id` must be a GUID → no path/query injection.
- Bound calls require **both** `entity_set` and `id`; unbound require **neither** (half-specified case rejected).

## Verification

- **Unit:** 13 new tests (bound/unbound paths, empty body, invalid name, binding mismatch, function URL building). Full suite: **124 passing**, lint + build green.
- **Live (against a real org):**
  - `PublishDuplicateRule` (bound) → polled → `statecode` 0→1 (Published); `UnpublishDuplicateRule` (unbound) → 1→0. ✅
  - `QualifyLead` (bound) → lead Qualified; Account + Opportunity created and retrievable by ID. ✅
  - Live testing **corrected the issue's example**: `PublishDuplicateRule` is **bound** (not unbound) while `UnpublishDuplicateRule` is unbound — README/CHANGELOG now document the real `$metadata` shape, plus a tip to check `IsBound` on a `404 "Resource not found for the segment"`.

## Note on safety

`invoke_action` can perform arbitrary mutating operations and is **intentionally ungated** for now. Capability-based access control (safe-by-default gating of writes/actions) is tracked separately in #45 / #46. `invoke_function` is read-only.

## Release

Bumps to **0.5.0** (`package.json` + lockfile) with a `## [0.5.0]` CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)